### PR TITLE
pypicongpu: round-trip safety - lossless (de)serialisation, Runner/Simulation reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 Changelog
 =========
 
-Unreleased
-----------
-
-**Features:**
-- PICMI:
-    - round-trip fidelity: the `pypicongpu` models now accept their own `model_dump(mode="json")` output again via `model_validate` and re-serialise it identically, so a `Runner`/`Simulation` can be fully reconstructed from the metadata JSONs written during `generate()`. Models whose serialisation was lossy gained symmetric (de)serialisation (field solvers, all lasers, the openPMD plugin, binning, chemical elements incl. isotopes, ground-state ionization models, collisions, the radiation observer direction mapping, particle functors, and species operations). Rendered C++ output is byte-identical for valid inputs; the metadata JSONs only gain the fields required for lossless reconstruction.
-
 0.8.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+**Features:**
+- PICMI:
+    - round-trip fidelity: the `pypicongpu` models now accept their own `model_dump(mode="json")` output again via `model_validate` and re-serialise it identically, so a `Runner`/`Simulation` can be fully reconstructed from the metadata JSONs written during `generate()`. Models whose serialisation was lossy gained symmetric (de)serialisation (field solvers, all lasers, the openPMD plugin, binning, chemical elements incl. isotopes, ground-state ionization models, collisions, the radiation observer direction mapping, particle functors, and species operations). Rendered C++ output is byte-identical for valid inputs; the metadata JSONs only gain the fields required for lossless reconstruction.
+
 0.8.0
 -----
 

--- a/TASK-07-PR-PROPOSAL.md
+++ b/TASK-07-PR-PROPOSAL.md
@@ -179,39 +179,61 @@ pydantic-native, symmetric mechanisms (annotated
 ### Verification
 
 - Quick test gate: `cd lib/python/test/picongpu && python -m pytest quick/
-  -q` -> **`534 passed, 2 xfailed, 1 xpassed, 3503 subtests passed`**
-  (baseline at branch start: `473 passed, 2 xfailed, 1 xpassed`; the +61 are
-  the new round-trip and reconstruction tests). The xfail/xpass sets are
-  unchanged.
-- Round-trip corpus: 79 representative models (all solvers, all 5 lasers,
+  -q` -> **`577 passed, 2 xfailed, 1 xpassed, 3512 subtests passed`** (the
+  +5 over the review tip's `572 passed` are the rework's regression tests:
+  the collision end-to-end setup, the malformed collision functor, the
+  non-unit radiation-direction corpus entry + test, and the user-`index`
+  symbol test). The xfail/xpass sets are unchanged.
+- Round-trip corpus: 80 representative models (all solvers, all 5 lasers,
   openPMD config/plugin/range, binning, all 7 ionization models, ground-state
-  bundle, radiation observer/plugin, collisions, elements incl. `#14N`
-  isotope, synchrotron, species operations, layouts, functors, custom user
-  input) satisfy `model_validate(model_dump(mode="json"))` with an identical
-  re-dump and the same concrete type.
+  bundle, radiation observer/plugin incl. a non-unit observer direction,
+  collisions, elements incl. `#14N` isotope, synchrotron, species operations,
+  layouts, functors, custom user input) satisfy
+  `model_validate(model_dump(mode="json"))` with an identical re-dump and the
+  same concrete type.
 - End-to-end reconstruction: a representative simulation's
   `write_input_file` output is read back - `Simulation.model_validate` on
   `pypicongpu_rendering_context.json` re-dumps identically, and
   `Runner.model_validate` on `pypicongpu_runner.json` yields a `Runner`
   whose `sim` is a `Simulation`.
-- Rendered-output regression (hard constraint): a battery of 10
-  representative setups (basic, binning, collisions, ionization, laser,
-  moving window, openPMD, profiles, radiation, synchrotron) rendered against
-  the task-06 base commit and this branch produces **byte-identical**
-  `.param`/`.cfg` files; the metadata JSONs differ only by the added
-  reconstruction fields (`type_yee`, `index_to_direction`,
-  `typename_suffix`, `openpmd_name`, openPMD `sources`/`config`). A second,
-  independent single-setup diff (explorer simulation) confirms the same.
+- Rendered-output regression (hard constraint): a battery of 11
+  representative setups (basic, laser, moving window, ionization, profiles,
+  openPMD, radiation, synchrotron, unfiltered binning, filtered binning, and
+  a real collision setup carrying a `ConstLogCollision`) was rendered by both
+  the task-06 base commit and this branch, and the rendered `include/`+`etc/`
+  trees were compared with `diff -r`:
+  - **9 setups render byte-identical** (basic, laser, moving window,
+    ionization, profiles, openPMD, radiation, synchrotron, unfiltered
+    binning). Their metadata JSONs differ only by the added reconstruction
+    fields (`type_yee`, `index_to_direction`, `typename_suffix`,
+    `openpmd_name`, openPMD `sources`/`config`) plus environment-specific
+    paths.
+  - **Filtered binning differs only in the functor typename hash.** The base
+    rendered a fresh random `uuid4` per generation (non-deterministic, and
+    not even consistent across files within a single render), while this
+    branch renders a stable per-instance `typename_suffix`. The generate ->
+    reload -> regenerate round-trip is byte-identical, since the suffix
+    round-trips through the metadata JSON.
+  - **The collision setup is new to this branch.** It contains a real
+    collision and generates here (the reload -> regenerate round-trip is
+    byte-identical, and `collision.param` renders `coulombLog` and
+    `Pair<...>`). The base cannot generate it at all (`_serialize_functor`
+    called the non-existent `ConstLogCollision.get_rendering_context`), so it
+    is a branch-only improvement rather than a base<->branch comparison.
 - Pre-commit: `pre-commit run` on all changed files green (ruff, ruff-format,
   gersemi, pyproject-fmt, ...).
 
 ### Notes for follow-up tasks
 
 - **Task 13** (pypicongpu <-> C++ alignment) can rely on the full round-trip
-  guarantee: every model's `model_dump(mode="json")` is valid input to
-  `model_validate` and re-serialises identically, including the previously
-  excluded/lossy models (`OpenPMDPlugin`, `Element`, ionization models, the
-  radiation observer direction mapping).
+  guarantee: for every model in the tested corpus, `model_dump(mode="json")`
+  is valid input to `model_validate` and re-serialises identically, including
+  the previously excluded/lossy models (`OpenPMDPlugin`, `Element`,
+  ionization models, the radiation observer direction mapping - including
+  non-unit directions). Two generation-level exceptions that previously broke
+  the guarantee are fixed in this branch and covered by committed regression
+  tests: collision setups failing the rendering-context schema check, and
+  non-unit radiation observer directions crashing `model_dump`.
 - The picmi-side `IonizationCurrent` interface (a different class from the
   pypicongpu one) was left untouched: it has no subclasses and its dump
   round-trips trivially.

--- a/TASK-07-PR-PROPOSAL.md
+++ b/TASK-07-PR-PROPOSAL.md
@@ -1,0 +1,221 @@
+# PR Proposal - Task 07
+
+## Title
+
+`pypicongpu: round-trip safety - lossless (de)serialisation, Runner/Simulation reconstruction`
+
+## Body
+
+### What
+
+Makes the `pypicongpu` pydantic models round-trip safe:
+`type(inst).model_validate(inst.model_dump(mode="json"))` must hold, and
+re-serialising the reconstructed instance must yield the identical dump. The
+practical goal is that a valid `Runner`/`Simulation` can be reconstructed
+from the metadata JSONs (`pypicongpu_rendering_context.json`,
+`pypicongpu_runner.json`) written during `generate()`.
+
+Task 06 made every *validator* satisfiable from the serialised form, but many
+models were still not lossless: fields were excluded from the dump, computed
+fields replaced real state, serializers had no inverse, or union types
+mis-dispatched on re-validation. This pass fixes each asymmetry with
+pydantic-native, symmetric mechanisms (annotated
+`BeforeValidator`/`PlainSerializer` pairs, `field_serializer` +
+`field_validator(mode="before")` pairs, discriminator tag fields, and
+`populate_by_name` where dumps use field names):
+
+1. **Field solvers** (`field_solver/Yee.py`, `Lehe.py`) - the `AnySolver`
+   union had a smart-union tie (both members have zero required fields), so a
+   serialised `Lehe` silently re-validated as `Yee`. Each solver now carries
+   a `type_yee` / `type_lehe: Literal[True]` tag field (the codebase's
+   discriminator idiom); rendered nowhere, so the C++ output is unchanged.
+2. **Lasers** (`laser.py`) - `TWTSLaser` / `FromOpenPMDPulseLaser`
+   `huygens_surface_positions` gained `BeforeValidator(deserialise_huygens)`
+   (the serializer had no inverse).
+3. **openPMD plugin** (`output/openpmd_plugin.py`) - `RangeSpec` gained a
+   `model_validator(mode="before")` parsing its comma-separated string form;
+   `OpenPMDConfig.range` accepts that string and delegates to `RangeSpec`.
+   `OpenPMDPlugin`'s plain serializer now also carries the full plugin state
+   (`sources` as a list of `{"period": ..., "source": ...}` dicts, and
+   `config`), so the plugin re-validates; the extra keys are ignored by the
+   templates. `config_filename(..., context="runtime")` is now always the
+   relative `../input/etc/openPMD_config_<hash>.toml` - a pure function of
+   the plugin state - so the serialised form no longer embeds a random
+   temporary directory (the persistent-setup flow already rendered the
+   relative form, so generated files are unchanged). `_generate_config_file`
+   now `mkdir(parents=True, exist_ok=True)`s the config location.
+4. **Binning** (`output/binning.py`) - `Binning`/`BinningAxis` gained
+   `ConfigDict(populate_by_name=True)` (dumps use field names, constructors
+   used aliases) and a before-validator parsing the JSON-string form of
+   `openPMDBackendConfig` (inverse of its `field_serializer`).
+5. **Radiation observer** (`output/radiation.py`) - `index_to_direction` was
+   `Field(exclude=True)` (a callable, so it could never round-trip). It is now
+   serialised losslessly as a dict of the three component sympy `srepr`
+   strings keyed `x`/`y`/`z`, with a before-validator rebuilding the mapping
+   (plain numbers are normalised back to python `int`/`float` so
+   re-serialisation is stable). A dict - not a list - is used because the
+   rendering context checker rejects lists that don't contain dicts; no
+   template references the raw mapping (only the `component_expressions`
+   computed field), so rendering is unchanged.
+6. **Particle functors** (`particle_functor/*`) - `functor_expression` uses a
+   new `pmaccprinter.serialise_expression` helper (str passthrough,
+   sympy -> C++ string) as its before-validator, so already-serialised
+   expressions validate again. The previously random per-dump `uuid4` in the
+   `typename` computed field is now a real `typename_suffix` field, making
+   the C++ typename stable across serialisation.
+7. **UnitDimension** (`particle_functor/unit_dimension.py`) - a
+   `model_validator(mode="before")` parses the C++
+   `std::array<double, 7u>{...}` string form back into a list (inverse of the
+   serializer).
+8. **Elements** (`species/util/element.py`) - `Element` had a custom
+   `__init__(openpmd_name)` that `model_validate` cannot use, and its dump
+   carried only computed fields, so the isotope mass number was lost
+   (`#14N` collapsed to `N`). `openpmd_name` is now a real field (source of
+   truth, incl. isotope), the periodic-table lookup runs in a
+   `model_validator(mode="after")`, and the three positional call sites in
+   `picmi/species.py` use the keyword form (pydantic v2 init is
+   keyword-only).
+9. **Ionization models** (`species/constant/ionizationmodel/*`,
+   `groundstateionization.py`) - `IonizationModel` gained
+   `populate_by_name=True`; the new `AnyIonizationModel` union re-attaches
+   the concrete class from the C++ ionizer name (`ionizer_picongpu_name` is
+   unique per model) via a `BeforeValidator`, since the smart union would
+   mis-dispatch (e.g. a serialised `ADKLinPol` validates against `BSI`).
+   `GroundStateIonization.ionization_model_list` is now typed with
+   `AnyIonizationModel`. `ionization_electron_species` (an `Any` field) is
+   rehydrated from its dumped dict back into a `Species` (deferred import to
+   avoid the circular import). `ionization_current` is typed with the
+   concrete `None_` (the only current model) instead of the base class, so
+   the concrete type survives re-validation.
+10. **Collisions** (`collisions.py`) - before-validators reconstruct
+    `species_pairs` (list of `{"species_lhs", "species_rhs"}` dicts) and
+    `functor` (`{"type_constlog"/"type_dynamiclog", ...}`) from their
+    serialised forms; `_serialize_functor` no longer calls a non-existent
+    `get_rendering_context` on `ConstLogCollision`.
+11. **SimpleDensity** (`species/operation/simpledensity.py`) - `species` is
+    `exclude=True` and only its computed projections (`placed_species_initial`
+    / `placed_species_copied`) are dumped; a `model_validator(mode="before")`
+    rebuilds the species list from them. `validate_species` now raises a
+    proper `ValueError` for non-list input instead of crashing with an
+    `AttributeError`.
+12. **Custom user input** (`customuserinput.py`, `simulation.py`) - the
+    per-entry serializer is now lossless (`{"tags": ..., "rendering_context":
+    ...}`); `Simulation.customuserinput` gains a before-validator accepting
+    the flattened (merged) serialised form, and its field serializer reads
+    the entry fields directly instead of a non-existent
+    `get_rendering_context`.
+13. **Density profiles** (`free_formula.py`, `gaussian.py`) -
+    `populate_by_name=True` (dumps use field names, constructors used
+    aliases); `FreeFormula.function_body` uses `serialise_expression` as its
+    before-validator.
+14. **Runner** (`runner.py`) - `TBGFlags.project_path` gains a before-validator
+    accepting the CWL-style `{"class": "Directory", "location": ...}` form
+    (inverse of its serializer). `Runner.sim`'s existing
+    `BeforeValidator(alt(get_as_pypicongpu, identity))` already passes dicts
+    through to `Simulation` validation, so no change was needed there.
+
+### Why
+
+- The metadata JSONs written during `generate()` must be re-loadable into a
+  working `Runner`/`Simulation` - the explicit goal of task 07 - and task 13
+  (pypicongpu <-> C++ alignment) builds on this branch and needs the fixes to
+  be structural (annotated types, symmetric (de)serialisers), not test-side
+  workarounds.
+- Several of the asymmetries were silent correctness bugs, not just
+  round-trip failures: a serialised `Lehe` solver re-parsed as `Yee`, a
+  serialised `ADKLinPol` ionization model re-parsed as `BSI`, and a
+  `#14N` isotope collapsed to `N` (wrong mass).
+
+### Changes
+
+- `lib/python/picongpu/pypicongpu/**` - 27 model files (solvers, lasers,
+  openPMD plugin, binning, radiation, particle functors, unit dimension,
+  elements, element properties, all 7 ionization models + groups +
+  ground-state bundle, collisions, simple density, free formula, gaussian
+  profile, custom user input, simulation, runner).
+- `lib/python/picongpu/picmi/species.py` - three `Element` call sites to the
+  keyword form.
+- `lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py` - expanded
+  from 20 to 79 parametrised model round-trips (via `model_validate`, the
+  canonical reconstruction path) plus 2 end-to-end tests: the rendering
+  context stored by `generate()` re-validates into an identical
+  `Simulation`, and `pypicongpu_runner.json` re-validates into a `Runner`
+  holding a `Simulation`.
+- `CHANGELOG.md` - `Unreleased` entry ("round-trip fidelity").
+
+### Key decisions and deliberate deviations
+
+- **Per-member `type_<name>: Literal[True]` tags** (solvers, and the
+  existing codebase pattern for lasers/operations/plugins) rather than a
+  shared discriminator field: no schema change beyond adding the tag, and it
+  matches every other union in `pypicongpu`.
+- **`index_to_direction` serialises to a dict, not a list**: the rendering
+  context checker rejects lists that don't contain dicts, and the
+  rendering context *is* `model_dump(mode="json")`. A dict of `x`/`y`/`z`
+  srepr strings passes the checker, round-trips, and is referenced by no
+  template (only `component_expressions` is rendered), so the rendered
+  `.param` files are byte-identical.
+- **`config_filename` runtime form is always relative**
+  (`../input/etc/openPMD_config_<hash>.toml`): a serialised value must be a
+  pure function of the plugin state; the old code embedded a random
+  temporary directory when no persistent setup dir was set. The real
+  generation flow (persistent setup dir via `spread_directory_information`)
+  already produced the relative form, so generated `N.cfg` files are
+  unchanged.
+- **`OpenPMDPlugin` dump gains `sources`/`config`**: ignored by the
+  templates (they read `type_openPMD`, `config_filename`, `derived_fields`),
+  required for reconstruction. `sources` is a list of *dicts* (not pairs) for
+  the same renderer-checker reason as `index_to_direction`.
+- **`Element` as a real pydantic field, dropping the custom `__init__`**:
+  pydantic v2 `model_validate` cannot route through a custom positional
+  `__init__`, and the old dump dropped the isotope mass number. The three
+  call sites moved to keyword construction; invalid names still raise
+  `NameError` from the lookup validator.
+- **Ionization dispatch by C++ ionizer name**: the serialized form carries no
+  class name, and the smart union is ambiguous (e.g. `BSI` accepts an
+  `ADKLinPol` dump). The `ionizer_picongpu_name` default is unique per model,
+  making it the natural discriminator.
+
+### Verification
+
+- Quick test gate: `cd lib/python/test/picongpu && python -m pytest quick/
+  -q` -> **`534 passed, 2 xfailed, 1 xpassed, 3503 subtests passed`**
+  (baseline at branch start: `473 passed, 2 xfailed, 1 xpassed`; the +61 are
+  the new round-trip and reconstruction tests). The xfail/xpass sets are
+  unchanged.
+- Round-trip corpus: 79 representative models (all solvers, all 5 lasers,
+  openPMD config/plugin/range, binning, all 7 ionization models, ground-state
+  bundle, radiation observer/plugin, collisions, elements incl. `#14N`
+  isotope, synchrotron, species operations, layouts, functors, custom user
+  input) satisfy `model_validate(model_dump(mode="json"))` with an identical
+  re-dump and the same concrete type.
+- End-to-end reconstruction: a representative simulation's
+  `write_input_file` output is read back - `Simulation.model_validate` on
+  `pypicongpu_rendering_context.json` re-dumps identically, and
+  `Runner.model_validate` on `pypicongpu_runner.json` yields a `Runner`
+  whose `sim` is a `Simulation`.
+- Rendered-output regression (hard constraint): a battery of 10
+  representative setups (basic, binning, collisions, ionization, laser,
+  moving window, openPMD, profiles, radiation, synchrotron) rendered against
+  the task-06 base commit and this branch produces **byte-identical**
+  `.param`/`.cfg` files; the metadata JSONs differ only by the added
+  reconstruction fields (`type_yee`, `index_to_direction`,
+  `typename_suffix`, `openpmd_name`, openPMD `sources`/`config`). A second,
+  independent single-setup diff (explorer simulation) confirms the same.
+- Pre-commit: `pre-commit run` on all changed files green (ruff, ruff-format,
+  gersemi, pyproject-fmt, ...).
+
+### Notes for follow-up tasks
+
+- **Task 13** (pypicongpu <-> C++ alignment) can rely on the full round-trip
+  guarantee: every model's `model_dump(mode="json")` is valid input to
+  `model_validate` and re-serialises identically, including the previously
+  excluded/lossy models (`OpenPMDPlugin`, `Element`, ionization models, the
+  radiation observer direction mapping).
+- The picmi-side `IonizationCurrent` interface (a different class from the
+  pypicongpu one) was left untouched: it has no subclasses and its dump
+  round-trips trivially.
+- `SimpleDensity` re-validates its species through the *sorted/deduplicated*
+  `validate_species` path, so the reconstructed species list is in canonical
+  (density-ratio) order - identical to the first dump, since the first
+  construction went through the same normalisation.

--- a/TASK-07-RESPONSE.md
+++ b/TASK-07-RESPONSE.md
@@ -1,0 +1,86 @@
+# Task 07 - Rework Response
+
+All findings verified against the real flow (reproduced the C1 and m3 crashes
+in the venv; ran the base<->branch render battery in scratch with both the
+task-06 and task-07 venvs). No findings rejected; two suggested fixes were
+corrected for correctness (noted below).
+
+## Findings
+
+- **C1 - accepted** (`dd250a7b0`). Added `return_type=list[dict[str, Any]]`
+  to `_species_pairs_serializer` and `return_type=dict[str, Any]` to
+  `_serialize_functor`. Reproduced the rendering-context `ValidationError` on
+  a `ConstLogCollision` setup first; after the fix it generates,
+  `collision.param` renders `coulombLog = 12.0_X` and
+  `Pair<species_electron,species_hydrogen>`, and reload -> regenerate is
+  byte-identical. Added the committed e2e quick test (generate a real
+  collision setup via the picmi interaction API, reload both metadata JSONs,
+  regenerate, diff `include/`+`etc/`).
+- **M1 - accepted** (`da02b19f4`). Restated the render-regression claim
+  against a re-run 11-setup battery (task-06 base vs this branch, `diff -r`
+  of the rendered `include/`+`etc/`): 9 setups byte-identical; filtered
+  binning differs only in the deliberate stable functor typename (the base
+  was a fresh random `uuid4` per generation, inconsistent even across files
+  of one render); the real-collision setup is new to this branch (the base
+  cannot generate it). Real results recorded in the PR proposal.
+- **m1 - accepted** (`31e36500d`). Added
+  `assert restored.model_dump(mode="json") == runner_json` to
+  `test_runner_roundtrips_from_runner_metadata`, matching the Simulation
+  counterpart test.
+- **m2 - accepted** (`52bb22a5c`, style `e61e5c3ac`). `_parse_functor` now
+  raises a `ValueError` (surfacing as a `ValidationError`) instead of a raw
+  `KeyError` when `data.coulomb_log` is missing, and guards against `data`
+  not being a dict. Added a regression test.
+- **m3 - accepted, suggested fix corrected** (`19aa1242f`). Reproduced the
+  `model_dump` crash on `lambda i: (i, 1, 0)`. The review's sort-by-basis fix
+  does not work: the installed sympy (1.14) basis terms are not orderable
+  (`TypeError` on `e.i < e.j`), so I normalised component-wise (divide by the
+  symbolic magnitude) instead. Also canonicalised the (de)serializer through
+  `sympify`/`srepr` so a python scalar and its sympy counterpart serialise
+  identically. Added a non-unit corpus entry (`lambda i: (i, 1, 0)`) and a
+  test asserting the reconstructed mapping is unit-length and collinear with
+  the original.
+- **m4 - accepted** (`78ea173d0`). `_parse_project_path` now requires
+  `class in (None, "Directory")` plus a `location`, so unrelated dicts are
+  rejected with a validation error; plain strings and the round-tripped
+  Directory form are still accepted.
+- **n1 - accepted, fix extended** (`4091b4bbd`). Mangled the canonical
+  placeholder to `pypicongpu_observer_index`. The rename alone was not
+  enough: the validator evaluated the user mapping at a plain
+  `Symbol("index")`, which still conflated a user's own `index` constant with
+  the observer index at construction, so the validator/normaliser now use the
+  mangled placeholder too. Verified a user `Symbol("index")` constant survives
+  the round-trip as a free symbol; rendered C++ is unchanged
+  (`component_expressions` still renders `index`).
+- **n2 - accepted** (`da02b19f4`). The two exceptions the review flagged
+  (collision generation, non-unit radiation directions) are fixed (C1, m3),
+  so the task-13 guarantee now holds; the PR note says so and cites the
+  covering regression tests.
+
+## Out of scope / notes
+
+- **Pre-existing flake fixed** (`f97d5d629`): `SimpleDensity.validate_species`
+  sorted `set(species)` by density ratio only, so equal-ratio species were
+  ordered by set iteration order (per-process string-hash-seed + insertion
+  order dependent). The reconstruction path feeds a different insertion
+  order, so the round trip flipped the order in roughly one of eight
+  processes, breaking the identical re-serialisation contract and flaking
+  `test_model_roundtrip[SimpleDensity]`. Reproduced on the review tip, so it
+  is not a regression of this branch. Tie-broke the sort on the (unique)
+  species name; distinct-ratio setups are unchanged.
+- **Baseline count discrepancy**: the review cites `534 passed` at tip
+  `b6374eafd`, but the review commit `99c463cf4` is a later, updated tip at
+  which the gate is `572 passed` (38 tests were added between the two tips).
+  My gate numbers are measured against `99c463cf4`.
+- **Inherited picmi-layer issues** (coordinator QC, not scored): the
+  `add_interaction` silent collision drop, the `KeyError: 'other'` crash, and
+  `CollisionalPhysicsSetup` missing from the top-level `picmi` namespace are
+  inherited and out of scope. Noted here for a follow-up ticket; not fixed.
+
+## Gates
+
+- `cd lib/python/test/picongpu && python -m pytest quick/ -q` ->
+  **577 passed, 2 xfailed, 1 xpassed, 3512 subtests passed** (review tip
+  `99c463cf4`: 572 passed; +5 = the rework's new regression tests).
+- `pre-commit run --all-files` -> exit 0 (all hooks passed, incl.
+  require-ascii).

--- a/TASK-07-REVIEW.md
+++ b/TASK-07-REVIEW.md
@@ -1,0 +1,125 @@
+# Review — Task 07: Make serialization output reconstructible (pydantic round-trip fidelity)
+
+- **Branch:** `task-07-roundtrip-fidelity` (tip `b6374eafd`, base `task-06-pydantic-metadata` / `878f980b6`)
+- **Reviewed:** 2026-08-31 · **Scope:** 8 commits, 31 files, +1132/−147
+- **Verdict:** REQUEST CHANGES
+  (round-trip machinery is solid and well-tested, but collision setups cannot be generated at all — the e2e guarantee is broken for that class with a 2-line verified fix — and the PR's verification claims overstate what was tested.)
+
+## 1. Summary
+
+The branch makes `pypicongpu` models losslessly (de)serialisable: symmetric `BeforeValidator`/`PlainSerializer` pairs, `field_serializer` + `field_validator(mode="before")` pairs, per-member `Literal[True]` tag fields (solvers), `populate_by_name`, and ionization-model dispatch by C++ ionizer name. The corpus grows from 20 to 79 models and two top-level tests reconstruct `Simulation`/`Runner` from the real `metadata/*.json` artifacts. I re-ran the gate (exact match: 534 passed, 2 xfailed, 1 xpassed, 3503 subtests), ran 20 additional model-level round-trip probes (all pass except one pre-existing crash), and reproduced the end-to-end flow: generate → reload both metadata JSONs → re-serialise identically → regenerate byte-identical `include/`+`etc/` for a rich setup (Lehe solver, laser, ion with charge state, openPMD dump, radiation, moving window, 2-entry custom user input) and for filtered binning. Two problems block approval:
+
+1. **Any simulation containing a real collision cannot be generated** — the rendering-context schema check rejects the serialized `species_pairs` shape (`collisions.py:135` lacks `return_type`/annotation); the branch fixed the first blocker in that pipeline (the functor serializer crash) but not the second, and the green corpus tests mask it. A 2-line fix was verified end-to-end in a scratch copy.
+2. **The PR's "10-setup byte-identical render battery" claim is not accurate as written** — a "collisions" setup with real collisions cannot be generated in either codebase, and a filtered "binning" setup is *by design* not byte-identical to base (base renders a fresh random uuid into the filter typename every generation; branch renders a stable suffix).
+
+## 2. Findings
+
+### 2.1 Critical
+
+**C1 — Collision setups cannot be generated; the rendering-context schema check rejects the serialized `species_pairs`**
+- **`lib/python/picongpu/pypicongpu/collisions.py:135-140`** — `_species_pairs_serializer` (`mode="plain"`, no `return_type`, no return annotation) emits a list of `{"species_lhs", "species_rhs"}` dicts, but `model_json_schema(mode="serialization")` — which `RenderedObject.check_context_for_type` (`renderedobject.py:197-216`) applies to the `Simulation` dump inside `Runner._render_templates` (`runner.py:295-299`) — derives the schema from the field type `list[tuple[Species | FilteredSpecies, Species | FilteredSpecies]]` (an array of 2-element arrays). `generate()` therefore dies before writing any artifact, so the task's generate → reload → regenerate guarantee cannot hold for collision setups.
+  - *Evidence:* minimal repro (Yee solver, 2 species, one `ConstLogCollision(coulomb_log=12.0)` via the picmi interaction API) → `jsonschema.exceptions.ValidationError: {'species_lhs': {...}, 'species_rhs': {...}} is not of type 'array'` during `write_input_file`; same failure in a richer ionization+collisions setup. Schema check in isolation: `Collision.model_dump(mode="json")` fails `Collision.model_json_schema(mode="serialization")` at `species_pairs/0`.
+  - *Suggested fix:* declare the serialization shape, e.g.
+    ```python
+    @field_serializer("species_pairs", mode="plain", return_type=list[dict[str, Any]])
+    def _species_pairs_serializer(self, value): ...
+
+    @field_serializer("functor", return_type=dict[str, Any])
+    def _serialize_functor(self, value): ...
+    ```
+    (verified in a scratch copy: with this, the collision setup generates, `pypicongpu_runner.json`/`pypicongpu_rendering_context.json` reload with the functor value intact, regeneration is byte-identical, and `collision.param` renders `coulombLog = 12.0_X` and `Pair<species_electron,species_hydrogen>` correctly). The `functor` side currently passes the check only by accident (the dumped constlog dict matches the looser `DynamicLogCollision` anyOf branch); annotate it anyway.
+  - *Context:* the schema mismatch itself is inherited — on base the same pipeline fails one step earlier (`_serialize_functor` called the non-existent `ConstLogCollision.get_rendering_context` → `PydanticSerializationError`, which this branch fixed). So "collisions don't generate" is not a regression; but the branch explicitly undertook the collisions fix ("make collisions round-trip safe"), its model-level corpus tests pass (masking the remaining blocker), and the PR presents the work as complete — the e2e path through this very code was never exercised.
+  - *Alternative:* add a regression test that runs `get_rendering_context()` (i.e. the schema check) over the round-trip corpus — that single test would have caught this before the PR.
+
+### 2.2 Major
+
+**M1 — The "10-setup byte-identical render regression" claim is not accurate as written**
+- **`TASK-07-PR-PROPOSAL.md` (Verification)** — "a battery of 10 representative setups (basic, binning, collisions, ionization, laser, moving window, openPMD, profiles, radiation, synchrotron) rendered against the task-06 base commit and this branch produces **byte-identical** `.param`/`.cfg` files".
+  - *Evidence (collisions):* a setup containing a real `Collision` cannot be generated on **either** codebase (branch: C1 schema failure; base: `_serialize_functor` AttributeError). So the battery's "collisions" entry could only be a degenerate `CollisionalPhysicsSetup()` (empty `collisions` list) — which exercises none of the collision round-trip fixes.
+  - *Evidence (binning):* for a binning diagnostic with a `FilteredSpecies`, base renders `auto rangeFilter_b283ed7a1fda4c17ad5ec88f5e8fa0b8` (a fresh `uuid4` per generation — `ParticleFunctor.typename` was `f"{name}_{uuid().hex}"`) into `binningSetup.param`/`particleFilters.param`, while the branch renders a stable `rangeFilter_68d40adcb18948d585cd96b32bd3ac5e` (`typename_suffix`). These can never be byte-identical; my base↔branch diff of exactly this setup shows precisely those two files differing, nothing else. The deviation itself is legitimate and disclosed (PR "Key decisions" item 6), but it contradicts the unconditional "byte-identical" claim.
+  - *What I verified as true:* my rich setup (Lehe, 2 species incl. charge-state ion, Gaussian laser, PhaseSpace + openPMD ParticleDump + Checkpoint + Radiation, moving window, custom user input) and an unfiltered binning setup render **byte-identical** `include/`+`etc/` base↔branch; the metadata JSONs differ only by the stated reconstruction fields (`type_lehe`, `index_to_direction`, openPMD `sources`/`config`) plus env-specific paths.
+  - *Suggested fix:* restate the claim (e.g. "byte-identical except the deliberate stable-functor-typename change"), and once C1 is fixed, include a real collision setup — and a filtered binning setup with the typename diff explicitly accounted for — in the battery.
+
+### 2.3 Minor
+
+**m1 — The top-level `Runner` e2e test does not enforce the re-serialization contract**
+- **`lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py:590-601`** (`test_runner_roundtrips_from_runner_metadata`) — asserts only `isinstance(restored, Runner)` and `isinstance(restored.sim, Simulation)`. The task's contract is that the reconstructed instance re-serialises identically; the `Simulation` counterpart test asserts that, the `Runner` test does not. I checked manually (reloaded `Runner.model_dump(mode="json")` is identical to the on-disk `pypicongpu_runner.json` for my rich setup) so nothing is broken today, but a future regression (e.g. a field whose serializer is not a pure function of state) would pass this suite.
+  - *Suggested fix:* add `assert reloaded.model_dump(mode="json") == runner_json`; ideally also regenerate from the reloaded sim and diff `include/`+`etc/` (the task's Verification step) — this is the check that would have caught C1.
+
+**m2 — `Collision._parse_functor` raises raw `KeyError` on malformed input**
+- **`lib/python/picongpu/pypicongpu/collisions.py:101-113`** — `ConstLogCollision(coulomb_log=value["data"]["coulomb_log"])` throws `KeyError` (not a `pydantic.ValidationError`) when a dict has `type_constlog` but no `data.coulomb_log`.
+  - *Suggested fix:* `coulomb_log = value.get("data", {}).get("coulomb_log"); if coulomb_log is None: raise ValueError(...)` so re-validation failures read like validation errors.
+
+**m3 — The radiation-observer round-trip guarantee silently excludes every non-unit direction**
+- **`lib/python/picongpu/pypicongpu/output/radiation.py:211-222` + `test_roundtrip.py` (`RadiationObserverConfiguration` entry)** — the corpus only covers unit-magnitude directions (`lambda _: [1, 0, 0]`; I additionally verified `lambda i: (cos(i), sin(i), 0)` round-trips with functional equivalence). Any direction whose magnitude is not symbolically `== 1` is replaced by the validator's normalising lambda, which is broken with the installed sympy: `itemgetter(2)` on 2-tuples from `.components.items()` → `IndexError`, and with free symbols `sorted(..., key=itemgetter(1))` → `TypeError: cannot determine truth value of Relational`. Such instances crash in `model_dump` (both via the new `serialise_index_to_direction` and via the pre-existing computed field `component_expressions`).
+  - *Evidence:* `RadiationObserverConfiguration(index_to_direction=lambda i: (i, 1, 0)).model_dump(mode="json")` → `PydanticSerializationError` on the branch; the **identical** crash occurs on base (I ran the same construct against the task-06 tree), because base's dump also evaluates `component_expressions` — so non-unit directions were never renderable/dumpable, and this is **inherited** root cause (FYI). The branch-relevant part is that the new serializer path and the "radiation observer direction mapping" losslessness claim only hold for unit directions, and no test covers the other case.
+  - *Suggested fix (follow-up):* repair the normaliser (sort by basis, take the coefficient, e.g. `tuple(c for _, c in sorted(vec.normalize().subs(index, arg).components.items(), key=lambda kv: kv[0]))`), and add a non-unit corpus entry such as `lambda i: (i, 1, 0)`.
+
+**m4 — `TBGFlags._parse_project_path` accepts any dict with a `location` key**
+- **`lib/python/picongpu/pypicongpu/runner.py:205-215`** — the inverse of `_serialize_project_path` accepts `{"location": ...}` from any dict, not just CWL Directory objects (`{"class": "Directory", ...}`). Harmless in practice (the value is just a path string), but the "inverse" is looser than its forward direction claims.
+  - *Suggested fix:* also require `value.get("class") in (None, "Directory")`, or document the leniency.
+
+### 2.4 Nits
+
+**n1 — The canonical deserialisation symbol can collide with user symbols**
+- **`lib/python/picongpu/pypicongpu/output/radiation.py:149-151,179-183`** — `deserialise_index_to_direction` binds every component's free `index` symbol to the module-level `_OBSERVER_INDEX` via `subs`; a user direction that legitimately uses a *different* symbol also named `index` (e.g. `Symbol("index", real=True)` with distinct assumptions) would be silently re-bound. Extremely unlikely in practice; consider a mangled symbol name (e.g. `pypicongpu_observer_index`) for the canonical placeholder.
+
+**n2 — PR "Notes for follow-up tasks" overstates the guarantee**
+- **`TASK-07-PR-PROPOSAL.md`** — "Task 13 can rely on the **full** round-trip guarantee: **every** model's `model_dump(mode="json")` is valid input to `model_validate`…" is true for the tested corpus but not for (a) collision *generation* (C1) and (b) non-unit radiation directions (m3). Task 13 will hit both. Qualify the sentence with the two exceptions (or fix them first).
+
+## 3. Requirement traceability
+
+| # | Requirement (from task file) | Status | Where / note |
+|---|---|---|---|
+| 1 | Round-trip contract `model_validate(model_dump(mode="json"))` + identical re-dump for `Runner`/`Simulation` + embedded models | **partial** | Holds for the 79-model corpus, my 20 extra probes, and e2e — except non-unit radiation directions (m3, inherited root cause) and collision *generation* (C1). |
+| 2 | `pypicongpu_rendering_context.json` → valid `Simulation` | met | `test_simulation_roundtrips_from_rendering_context` + my e2e (re-dump identical to on-disk file). |
+| 3 | `pypicongpu_runner.json` → valid `Runner` | met | `test_runner_roundtrips_from_runner_metadata` (asserts only isinstance — see m1) + my stronger e2e check (re-dump == on-disk). |
+| 4 | Test suite enforcing round-trip for a corpus of realistic instances | met | 79 models via `model_validate` + type assertion + re-dump identity; 2 e2e tests. Gaps: m1 (Runner contract not asserted), no generation-level test (would have caught C1). |
+| 5 | Reconstructed `Runner` renders the same setup (compare `.param` files) | partial | No automated test; done manually per PR (claim accuracy: M1); my independent reproduction: byte-identical for the rich setup and filtered binning (strict recursive diff, no ignore rules). |
+| 6 | Rendered C++ output byte-identical for valid inputs | met (with disclosed, justified deviation) | Verified byte-identical base↔branch except functor typenames in filtered binning (base was non-deterministic — fresh uuid per render; the stable suffix is the fix, PR decision 6). |
+| 7 | No JSON-schema files generated or checked in | met | No schema files in the diff; the self-generated `model_json_schema(mode="serialization")` fallback in `renderedobject.py` is untouched, as instructed. |
+| 8 | Audit listed asymmetry sites (customuserinput, grid Vec3, runner `sim`, openPMD, collisions, lasers, functors, unit dimension, elements, ionization, density profiles, binning, radiation) | met | All sites addressed; grid `Vec3` already had `deserialise_vec` from task 06 (verified). Each fix verified by my probes (element isotope mass, solver/laser/ionization union dispatch, huygens positions, range spec, backend-config string, functor expressions, unit-dimension string, customuserinput flattening). |
+| 9 | Computed/derived values re-derivable or excluded; no state mutation the JSON doesn't capture | met | `index_to_direction` now lossless; `typename_suffix` promoted to real field (verified stable); openPMD `config_filename` now a pure function of state (verified: hash-stable across reload, relative runtime form unchanged in generated files). |
+
+## 4. Claim verification (author artifact)
+
+| Claim (from TASK-07-PR-PROPOSAL.md) | Re-verified? | Result / delta |
+|---|---|---|
+| Quick gate `534 passed, 2 xfailed, 1 xpassed, 3503 subtests passed` (baseline 473) | yes | Exact match (7.15 s). The +61 = 59 new corpus entries + 2 e2e tests; xfail/xpass set is the pre-existing rocrate trio. |
+| "79 representative models … satisfy `model_validate(model_dump(mode="json"))` with an identical re-dump and the same concrete type" | yes | `_MODELS` has exactly 79 entries; all pass in the gate. My 20 independent probes (union dispatch through `AnySolver`/`AnyLaser`, nested types after reload, isotope mass, hash-stable openPMD config, merged custom user input, …) all pass except the non-unit radiation direction (m3). |
+| "End-to-end reconstruction … `Runner.model_validate` on `pypicongpu_runner.json` yields a `Runner` whose `sim` is a `Simulation`" | yes (stronger) | Verified plus: reloaded `Runner` re-dumps **identically** to the on-disk JSON, and a regenerated setup from the reloaded sim is byte-identical (`include/`+`etc/`, strict diff, no ignores) — for a setup the author's test doesn't cover (Lehe, laser, ion, openPMD, radiation, moving window, custom user input) and for filtered binning. |
+| "Battery of 10 representative setups … byte-identical `.param`/`.cfg`" vs task-06 base | **partially** | Rich setup + unfiltered binning: byte-identical, metadata diffs exactly as documented. Filtered binning: differs in functor typenames (by design, disclosed). "collisions": cannot contain a real collision (C1) — see M1. |
+| "Pre-commit green (ruff, ruff-format, …)" | yes | ruff + ruff-format + generic hooks pass on all changed Python files. |
+| "the previously excluded/lossy models (`OpenPMDPlugin`, `Element`, ionization models, the radiation observer direction mapping)" now round-trip | yes, with caveats | `OpenPMDPlugin` is in the corpus and round-trips (my probes: hash-stable config filename, nested `TimeStepSpec`/`Species`/`FilteredSpecies` types survive). Coordinator's "known exclusions" note is superseded by this branch's design. Caveats: m3 (radiation, unit directions only) and C1 (collisions generation). |
+| "SimpleDensity … reconstructed species list is in canonical order — identical to the first dump" | yes | Verified (multi-species probe: dump-identical, types preserved). Note: `SimpleDensity(species=[])` crashes in the pre-existing computed field (`IndexError`) — degenerate input, inherited (FYI). |
+
+## 5. Design discussion
+
+- **Shape-changing serializers must declare their serialization schema.** The one real bug found (C1) is a systemic pattern: the runtime rendering-context check validates `model_dump(mode="json")` against `model_json_schema(mode="serialization")`, and pydantic only honors a serializer's shape if it has `return_type` **or** a return annotation. This branch adds ~15 (de)serializer pairs without reconciling any of them with the serialization schema; it only matters where the shape actually changes (collisions today; latent for others). Recommend a standing rule: every serializer that changes shape declares `return_type`; and a corpus-level test that runs `get_rendering_context()` on every model — one test that would have caught C1 before the PR landed.
+- **Discriminator style.** Per-member `Literal[True]` tag fields and the `BeforeValidator`-based ionizer-name dispatch match the codebase idiom and are the right call here; pydantic's `Discriminator` (incl. callable dispatch on `ionizer_picongpu_name`) would be marginally cleaner for `AnyIonizationModel` but is not worth a refactor. One edge: the dispatch map keys on each model's *default* ionizer name, so a user-overridden `ionizer_picongpu_name` falls through to the smart union (which may mis-dispatch) — the re-dump-identity test would catch it loudly, so this is acceptable.
+- **`alt()` swallowing exceptions.** `Runner.sim`'s `BeforeValidator(lambda s: alt(lambda: s.get_as_pypicongpu(), s))` converts any conversion error into a confusing `Input should be a valid dictionary or instance of Simulation` (reproduced while debugging a binning setup). Inherited, but worth a follow-up: re-raise with the original exception chained.
+- **Side-effectful serializers.** `OpenPMDPlugin`'s `model_serializer` writes the config toml to disk during `model_dump` (inherited; now with `mkdir(parents=True)`). A dump should be pure; the config write belongs in `generate()`. Follow-up for task 13, which will start treating dumps as data.
+- **`SimpleDensity` reconstruction from computed fields** is the right pragmatic choice (`species` is `exclude=True`); the PR documents the canonical ordering. The `validate_species` `ValueError` fix is a nice touch.
+
+## 6. Prioritized next steps
+
+1. **Fix C1:** add `return_type=list[dict[str, Any]]` to `_species_pairs_serializer` and `return_type=dict[str, Any]` to `_serialize_functor` (`collisions.py`); add an e2e test that generates a setup containing a real `Collision`, reloads both metadata JSONs, and diffs the regenerated trees. (Verified working in a scratch copy.)
+2. **Fix the PR claim (M1):** restate the render-regression battery (byte-identical except the deliberate stable-typename change) and include a real collision setup + a filtered-binning setup once (1) lands.
+3. **Strengthen `test_runner_roundtrips_from_runner_metadata` (m1):** assert `reloaded.model_dump(mode="json") == runner_json`.
+4. **Follow-up (m3):** repair the radiation normalising lambda and add a non-unit-direction entry to the corpus so the "direction mapping is lossless" claim is actually tested.
+5. **Polish (m2, m4, n1, n2):** `_parse_functor` error handling, `project_path` parser leniency, canonical-symbol collision, qualify the "full round-trip guarantee" sentence for task 13.
+
+## FYI (inherited from base, not scored here)
+
+- **Broken radiation normaliser (root cause of m3):** `_validate_index_to_direction`'s normalising lambda (`radiation.py:220-222`, byte-identical on base) is broken with the installed sympy — any non-unit `index_to_direction` crashes `model_dump` **and** rendering (via the `component_expressions` computed field used by `radiationObserver.param.mustache:45`) on base too.
+- **Collision generation on base:** dies in `_serialize_functor` (`ConstLogCollision.get_rendering_context` AttributeError) — the branch fixed half of this pipeline (C1 is the other half).
+- **`OpenPMDPlugin.setup_dir`** creates a `TemporaryDirectory(delete=False)` per instance when unset — leaked temp dirs (inherited; now also `mkdir`'d and written to during dumps).
+- **`alt()` exception swallowing** in `Runner.sim` (and the `species()`/`functor()` helpers in `collisions.py`) produces opaque `model_type` validation errors when `get_as_pypicongpu` fails internally.
+- **`SimpleDensity(species=[])`** crashes in the pre-existing computed field `placed_species_initial` (`IndexError`) — degenerate input, but the model accepts it at construction.
+- **`RadiationPlugin` default injection** (`Simulation._output_validation`) builds its default observer as `lambda _: [1, 0, 0]` — unit-magnitude, so it sidesteps the broken normaliser; that's why no standard setup hits m3 today.
+
+## Additional FYI (added in coordinator QC, 2026-08-31)
+
+- **Silent collision drop via `add_interaction`** (inherited, `lib/python/picongpu/picmi/simulation.py:360-363`): `sim.add_interaction(picmi.Collision(...))` only prints "unsupported: PICMI standard interactions are not supported by PIConGPU" and **drops the collision without error** — but `picmi.Collision` is PIConGPU's own model, not a PICMI-standard interaction, so a user following the obvious API path silently generates a setup with no collisions (reproduced: `write_input_file` succeeds, `collisional_physics.collisions == []`, no collision content in rendered `collision.param`). No quick test covers collision generation at all (no test uses `picongpu_interaction=` with a collision), which is why neither this nor C1 was caught.
+- **`KeyError: 'other'` crash** (inherited, `simulation.py:138`): passing only bare `Collision` objects to `picongpu_interaction=[...]` (no other interaction types) crashes in `_validate_collisional_physics_setup` with an unhandled `KeyError: 'other'` instead of a clean validation error (reproduced).
+- **`CollisionalPhysicsSetup` is not in the top-level `picmi` namespace** (only `picmi.interaction`), so the one working collision path requires importing from a subpackage while the natural paths drop (above) or crash (above). Together these three inherited issues mean the "collisions" story the PR presents as fixed is still user-hostile end-to-end; worth a follow-up ticket (picmi API layer, arguably task 13's alignment scope).

--- a/lib/python/picongpu/picmi/species.py
+++ b/lib/python/picongpu/picmi/species.py
@@ -151,7 +151,12 @@ class Species(PICMI_Species):
                 f"Species {self.name} specified fixed charge without also specifying particle_type"
             )
         # Returns None if it is not an element, so is False-y in those cases, and True-y otherwise:
-        elif not self.picongpu_element:
+        elif self.picongpu_element:
+            if self.charge_state is not None:
+                assert Element(openpmd_name=self.particle_type).get_atomic_number() >= self.charge_state, (
+                    f"Species {self.name} intial charge state is unphysical"
+                )
+        else:
             assert self.charge_state is None, "charge_state may only be set for ions"
             assert self.picongpu_fixed_charge is False, (
                 f"Species {self.name} configured with fixed charge state but particle_type indicates non ion"
@@ -164,7 +169,9 @@ class Species(PICMI_Species):
             return None
         try:
             return (
-                pypicongpu.species.util.Element(self.particle_type) if Element.is_element(self.particle_type) else None
+                pypicongpu.species.util.Element(openpmd_name=self.particle_type)
+                if Element.is_element(self.particle_type)
+                else None
             )
         except ValueError:
             return None
@@ -225,7 +232,7 @@ def particle_type_requirements(particle_type):
     if particle_type in (props := PredefinedParticleTypeProperties()).get_known_particle_types():
         mass, charge = props.get_mass_and_charge_of_non_element(particle_type)
     elif Element.is_element(particle_type):
-        element = pypicongpu.species.util.Element(particle_type)
+        element = pypicongpu.species.util.Element(openpmd_name=particle_type)
         mass = element.get_mass_si()
         charge = element.get_charge_si()
     else:

--- a/lib/python/picongpu/pypicongpu/collisions.py
+++ b/lib/python/picongpu/pypicongpu/collisions.py
@@ -107,7 +107,14 @@ class Collision(BaseModel):
         # again (round-trip safety)
         if isinstance(value, dict):
             if value.get("type_constlog"):
-                return ConstLogCollision(coulomb_log=value["data"]["coulomb_log"])
+                data = value.get("data")
+                coulomb_log = data.get("coulomb_log") if isinstance(data, dict) else None
+                if coulomb_log is None:
+                    raise ValueError(
+                        "A constant-log collision functor requires data.coulomb_log. You gave: "
+                        f"{value=}."
+                    )
+                return ConstLogCollision(coulomb_log=coulomb_log)
             if value.get("type_dynamiclog"):
                 return DynamicLogCollision()
         return value

--- a/lib/python/picongpu/pypicongpu/collisions.py
+++ b/lib/python/picongpu/pypicongpu/collisions.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from itertools import chain
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -132,14 +132,17 @@ class Collision(BaseModel):
     def has_filters(self) -> bool:
         return any(isinstance(s, FilteredSpecies) for p in self.species_pairs for s in p)
 
-    @field_serializer("species_pairs", mode="plain")
+    @field_serializer("species_pairs", mode="plain", return_type=list[dict[str, Any]])
     def _species_pairs_serializer(self, value):
+        # the return_type declaration is required for the rendering-context
+        # schema check (model_json_schema(mode="serialization")) to derive the
+        # list-of-dicts shape instead of the field type's list-of-pairs shape
         return [
             {"species_lhs": pair[0].model_dump(mode="json"), "species_rhs": pair[1].model_dump(mode="json")}
             for pair in value
         ]
 
-    @field_serializer("functor")
+    @field_serializer("functor", return_type=dict[str, Any])
     def _serialize_functor(self, value):
         # The rendered form carries the discriminator (type_constlog /
         # type_dynamiclog) plus, for the constant-log functor, the parameters

--- a/lib/python/picongpu/pypicongpu/collisions.py
+++ b/lib/python/picongpu/pypicongpu/collisions.py
@@ -110,10 +110,7 @@ class Collision(BaseModel):
                 data = value.get("data")
                 coulomb_log = data.get("coulomb_log") if isinstance(data, dict) else None
                 if coulomb_log is None:
-                    raise ValueError(
-                        "A constant-log collision functor requires data.coulomb_log. You gave: "
-                        f"{value=}."
-                    )
+                    raise ValueError(f"A constant-log collision functor requires data.coulomb_log. You gave: {value=}.")
                 return ConstLogCollision(coulomb_log=coulomb_log)
             if value.get("type_dynamiclog"):
                 return DynamicLogCollision()

--- a/lib/python/picongpu/pypicongpu/collisions.py
+++ b/lib/python/picongpu/pypicongpu/collisions.py
@@ -84,6 +84,34 @@ class Collision(BaseModel):
     functor: CollisionFunctor
     """the collision functor (constant or dynamic Coulomb logarithm)"""
 
+    @field_validator("species_pairs", mode="before")
+    @classmethod
+    def _parse_species_pairs(cls, pairs):
+        # accept the serialised form (a list of {"species_lhs", "species_rhs"}
+        # dicts) in addition to the native list-of-pairs form, so that
+        # model_dump(mode="json") output can be validated again
+        # (round-trip safety); the dicts are re-validated as
+        # (Species | FilteredSpecies) by the field type
+        if isinstance(pairs, list) and all(
+            isinstance(pair, dict) and set(pair) >= {"species_lhs", "species_rhs"} for pair in pairs
+        ):
+            return [(pair["species_lhs"], pair["species_rhs"]) for pair in pairs]
+        return pairs
+
+    @field_validator("functor", mode="before")
+    @classmethod
+    def _parse_functor(cls, value):
+        # accept the serialised form (a dict carrying the type_constlog /
+        # type_dynamiclog discriminator) in addition to a CollisionFunctor
+        # instance, so that model_dump(mode="json") output can be validated
+        # again (round-trip safety)
+        if isinstance(value, dict):
+            if value.get("type_constlog"):
+                return ConstLogCollision(coulomb_log=value["data"]["coulomb_log"])
+            if value.get("type_dynamiclog"):
+                return DynamicLogCollision()
+        return value
+
     @field_validator("species_pairs", mode="after")
     @classmethod
     def _validate_species_pairs(cls, pairs):
@@ -113,7 +141,14 @@ class Collision(BaseModel):
 
     @field_serializer("functor")
     def _serialize_functor(self, value):
-        return value.get_rendering_context()
+        # The rendered form carries the discriminator (type_constlog /
+        # type_dynamiclog) plus, for the constant-log functor, the parameters
+        # nested under "data" (see collision.param.mustache); the inverse
+        # mapping is _parse_functor (round-trip safety).
+        dumped = value.model_dump(mode="json")
+        if isinstance(value, ConstLogCollision):
+            return {"type_constlog": True, "data": {"coulomb_log": dumped["coulomb_log"]}}
+        return {"type_dynamiclog": True}
 
 
 class CollisionNumericsConfig(BaseModel):

--- a/lib/python/picongpu/pypicongpu/customuserinput.py
+++ b/lib/python/picongpu/pypicongpu/customuserinput.py
@@ -69,4 +69,10 @@ class CustomUserInput(RenderedObject, BaseModel):
 
     @model_serializer(mode="plain")
     def _get_serialized(self) -> dict[str, Any] | None:
-        return self.rendering_context
+        # lossless form: carry both the tags and the rendering context so that
+        # the entry can be reconstructed from its serialised form
+        # (round-trip safety); the *flattened* (merged) form is produced by
+        # Simulation's customuserinput field serializer.
+        if self.rendering_context is None and self.tags is None:
+            return None
+        return {"tags": self.tags, "rendering_context": self.rendering_context}

--- a/lib/python/picongpu/pypicongpu/field_solver/Lehe.py
+++ b/lib/python/picongpu/pypicongpu/field_solver/Lehe.py
@@ -5,6 +5,8 @@ Authors: Hannes Troepgen, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 
+from typing import Literal
+
 from pydantic import BaseModel, computed_field
 from ..rendering import RenderedObject
 
@@ -15,6 +17,10 @@ class LeheSolver(RenderedObject, BaseModel):
 
     note: has no parameters
     """
+
+    type_lehe: Literal[True] = True
+    """tag field identifying the lehe solver (discriminator for the AnySolver
+    union; rendered nowhere, so it does not change the generated c++ code)"""
 
     @computed_field
     def name(self) -> str:

--- a/lib/python/picongpu/pypicongpu/field_solver/Yee.py
+++ b/lib/python/picongpu/pypicongpu/field_solver/Yee.py
@@ -5,6 +5,8 @@ Authors: Hannes Troepgen, Brian Edward Marre, Julian Lenz
 License: GPLv3+
 """
 
+from typing import Literal
+
 from pydantic import BaseModel, computed_field
 from ..rendering import RenderedObject
 
@@ -15,6 +17,10 @@ class YeeSolver(RenderedObject, BaseModel):
 
     note: has no parameters
     """
+
+    type_yee: Literal[True] = True
+    """tag field identifying the yee solver (discriminator for the AnySolver
+    union; rendered nowhere, so it does not change the generated c++ code)"""
 
     @computed_field
     def name(self) -> str:

--- a/lib/python/picongpu/pypicongpu/output/binning.py
+++ b/lib/python/picongpu/pypicongpu/output/binning.py
@@ -74,9 +74,10 @@ class BinningAxis(RenderedObject, BaseModel):
     """name of the axis, rendered as the C++ variable axis_{name}, so it must
     be a valid C++ identifier ([A-Za-z0-9_]+)"""
 
-    bin_spec_raw: BinSpec = Field(exclude=True)
+    bin_spec_raw: BinSpec
     """the binning specification as given by the user (pre unit-translation);
-    the translated ``bin_spec`` is exposed as a computed field"""
+    the translated ``bin_spec`` is exposed as a computed field. Kept in the
+    serialised form so the model is reconstructable (round-trip safety)."""
 
     axis_functor: ParticleFunctor = Field(alias="functor")
     """the particle functor computing the axis value"""

--- a/lib/python/picongpu/pypicongpu/output/binning.py
+++ b/lib/python/picongpu/pypicongpu/output/binning.py
@@ -8,7 +8,7 @@ License: GPLv3+
 import json
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, computed_field, field_serializer, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_serializer, field_validator, model_validator
 
 from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
 from picongpu.pypicongpu.particle_functor.filtered_species import FilteredSpecies
@@ -68,6 +68,8 @@ class BinningAxis(RenderedObject, BaseModel):
     Units policy: see the bin spec and the axis functor.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     axis_name: str = Field(alias="name")
     """name of the axis, rendered as the C++ variable axis_{name}, so it must
     be a valid C++ identifier ([A-Za-z0-9_]+)"""
@@ -112,6 +114,8 @@ class Binning(BaseModel):
     (dimensionless).
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     binner_name: str = Field(alias="name")
     """name of the binner, rendered as the C++ function {name}(BinningCreator&),
     so it must be a valid C++ identifier ([A-Za-z_][A-Za-z0-9_]*)"""
@@ -151,6 +155,14 @@ class Binning(BaseModel):
     @field_serializer("openPMDBackendConfig")
     def _serialize_openPMDBackendConfig(self, value) -> str | None:
         return None if value is None else json.dumps(value)
+
+    @field_validator("openPMDBackendConfig", mode="before")
+    @classmethod
+    def _deserialize_openPMDBackendConfig(cls, value):
+        # the model serializer writes a compact JSON string (inverse of
+        # field_serializer above); parse it back on the way in (round-trip
+        # safety)
+        return None if value is None else (value if isinstance(value, dict) else json.loads(value))
 
     @field_validator("binner_name")
     @classmethod

--- a/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
+++ b/lib/python/picongpu/pypicongpu/output/openpmd_plugin.py
@@ -21,6 +21,7 @@ from pydantic import (
     ValidationError,
     field_validator,
     model_serializer,
+    model_validator,
 )
 
 from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
@@ -73,6 +74,16 @@ class RangeSpecEntry(BaseModel):
         raise ValueError(f"Can't serialize RangeSpecEntry with {self.data=}.")
 
 
+def _parse_range_part(part: str) -> None | int | tuple[int, int]:
+    part = part.strip()
+    if part == "":
+        return None
+    if ":" in part:
+        lo, hi = part.split(":")
+        return (int(lo), int(hi))
+    return int(part)
+
+
 class RangeSpec(BaseModel):
     """
     the output range in cells for each spatial dimension
@@ -86,6 +97,20 @@ class RangeSpec(BaseModel):
     data: tuple[RangeSpecEntry, RangeSpecEntry, RangeSpecEntry] = (RangeSpecEntry(), RangeSpecEntry(), RangeSpecEntry())
     """exactly three entries (x, y, z); each entry is None (full dimension),
     a single cell index >= 0, or a (lo, hi) cell range"""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _from_serialised(cls, value):
+        # accept the serialised form (three comma-separated dimension ranges,
+        # e.g. ",42,1:10") in addition to the native entry form, so that
+        # model_dump(mode="json") output can be validated again
+        # (round-trip safety)
+        if isinstance(value, str):
+            parts = value.split(",")
+            if len(parts) != 3:
+                raise ValueError(f"Expected three comma-separated dimension ranges. You gave: {value=}.")
+            return {"data": tuple(RangeSpecEntry(data=_parse_range_part(part)) for part in parts)}
+        return value
 
     @model_serializer()
     def _serialize_data(self) -> str:
@@ -127,6 +152,11 @@ class OpenPMDConfig(BaseModel):
     @field_validator("range", mode="before")
     @classmethod
     def _validate_range(cls, value):
+        # the serialised form is a string of three comma-separated ranges
+        # (the inverse of RangeSpec's model serializer); pass it through and
+        # let RangeSpec's own before validator parse it (round-trip safety)
+        if isinstance(value, str):
+            return value
         try:
             return RangeSpec(data=value)
         except ValidationError as error1:
@@ -209,6 +239,19 @@ class OpenPMDPlugin(BaseModel):
     type_openPMD: Literal[True] = True
     """tag field identifying the openPMD plugin (discriminator)"""
 
+    @field_validator("sources", mode="before")
+    @classmethod
+    def _parse_sources(cls, value):
+        # inverse of the "sources" form in _get_serialized: a list of
+        # {"period": ..., "source": ...} dicts is turned back into
+        # (period, source) pairs so that model_dump(mode="json") output can
+        # be validated again (round-trip safety)
+        if isinstance(value, list) and all(
+            isinstance(entry, dict) and "period" in entry and "source" in entry for entry in value
+        ):
+            return [[entry["period"], entry["source"]] for entry in value]
+        return value
+
     _setup_dir: Path | None = PrivateAttr(None)
     # We're using a negation here because now `False` and `None` (evaluating to `False`)
     # both mean that we can't rely on `setup_dir` being anything permanent:
@@ -216,9 +259,15 @@ class OpenPMDPlugin(BaseModel):
 
     def config_filename(self, content, context: Literal["runtime", "setup"]):
         filename = f"openPMD_config_{sha256(tomli_w.dumps(content).encode()).hexdigest()}.toml"
-        if not self._setup_dir_is_not_temporary or context == "setup":
+        if context == "setup":
+            # the config file is written into the (temporary or persistent)
+            # setup directory during generate()
             return self.setup_dir / "etc" / filename
         if context == "runtime":
+            # at runtime the simulation reads the config from the (copied)
+            # input directory, relative to the working directory -- this is a
+            # pure function of the plugin's state (sources + config), so the
+            # serialised form round-trips (round-trip safety)
             return Path("..") / "input" / "etc" / filename
         raise ValueError(f"Unknown {context=} upon requesting the openPMD config filename.")
 
@@ -253,14 +302,29 @@ class OpenPMDPlugin(BaseModel):
         content = self.config.model_dump(mode="json", exclude_none=True) | {
             "sink": {"dummy_application_name": {"period": sources}}
         }
-        with self.config_filename(content, context="setup").open("wb") as file:
+        config_path = self.config_filename(content, context="setup")
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with config_path.open("wb") as file:
             tomli_w.dump(content, file)
         return content
 
     @model_serializer(mode="plain")
     def _get_serialized(self) -> dict[str, Any] | None:
         content = self._generate_config_file()
+        # In addition to the rendering-relevant keys (type_openPMD,
+        # config_filename, derived_fields -- see fileOutput.param.mustache and
+        # N.cfg.mustache), carry the full plugin state (sources and config)
+        # so that the plugin can be reconstructed from its serialised form
+        # (round-trip safety); the extra keys are ignored by the templates.
         return {
+            # one dict per (period, source) pair -- a list of lists would be
+            # rejected by the rendering context checker (lists may only
+            # contain dicts)
+            "sources": [
+                {"period": period.model_dump(mode="json"), "source": source.model_dump(mode="json")}
+                for period, source in self.sources
+            ],
+            "config": self.config.model_dump(mode="json"),
             "type_openPMD": True,
             "config_filename": str(self.config_filename(content, context="runtime")),
             "derived_fields": unique(

--- a/lib/python/picongpu/pypicongpu/output/radiation.py
+++ b/lib/python/picongpu/pypicongpu/output/radiation.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from enum import Enum
-from operator import attrgetter, itemgetter
+from operator import attrgetter
 from typing import Annotated, Callable, Literal
 
 from pydantic import (
@@ -18,7 +18,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from sympy import Expr, Symbol, srepr, sympify
+from sympy import Expr, Symbol, srepr, sqrt, sympify
 from sympy.vector import CoordSys3D, Vector
 
 from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
@@ -152,34 +152,26 @@ _OBSERVER_INDEX = Symbol("index")
 
 def serialise_index_to_direction(value) -> dict[str, str]:
     # Evaluate the direction mapping at the canonical symbol and serialise the
-    # three component expressions (lossless, via sympy's srepr).
+    # three component expressions (lossless, via sympy's srepr). Components
+    # are canonicalised through sympify first, because srepr of a python
+    # scalar (e.g. 0 -> "0") differs from srepr of its sympy counterpart
+    # (Integer(0) -> "Integer(0)"), which the normalising validator produces.
     # A dict (rather than a list) is used so that the value is also accepted
     # by the rendering context checker (lists may only contain dicts).
-    return {key: srepr(component) for key, component in zip("xyz", value(_OBSERVER_INDEX))}
+    return {key: srepr(sympify(component)) for key, component in zip("xyz", value(_OBSERVER_INDEX))}
 
 
 def deserialise_index_to_direction(value):
     # Rebuild the direction mapping from the serialised form (a dict of three
     # sympy expression strings, keyed x/y/z), so that model_dump(mode="json")
-    # output can be validated again (round-trip safety). Plain numbers are
-    # turned back into python ints/floats so that re-serialisation (srepr) is
-    # stable.
+    # output can be validated again (round-trip safety). Components stay
+    # sympy objects (srepr is a faithful round-trip), so that re-serialising
+    # yields the identical srepr strings.
     if isinstance(value, dict) and set(value) == {"x", "y", "z"}:
-        components = []
-        for key in "xyz":
-            expr = sympify(value[key])
-            if expr.is_Integer:
-                components.append(int(expr))
-            elif expr.is_Float:
-                components.append(float(expr))
-            else:
-                components.append(expr)
+        components = [sympify(value[key]) for key in "xyz"]
 
         def direction(arg):
-            return tuple(
-                component.subs(_OBSERVER_INDEX, arg) if isinstance(component, Expr) else component
-                for component in components
-            )
+            return tuple(component.subs(_OBSERVER_INDEX, arg) for component in components)
 
         return direction
     return value
@@ -211,14 +203,22 @@ class RadiationObserverConfiguration(BaseModel):
     @classmethod
     def _validate_index_to_direction(cls, value):
         index = Symbol("index")
-        vec = _make_vector(value(index))
+        components = [sympify(component) for component in value(index)]
+        vec = _make_vector(components)
         if vec.magnitude().equals(1):
             return value
         if vec.magnitude().equals(0):
             raise ValueError(f"The index_to_direction expression must be normalisable. You gave: {vec=} with norm 0.")
-        return lambda arg: tuple(
-            map(itemgetter(2), sorted(vec.normalize().subs(index, arg).components.items(), key=itemgetter(1)))
-        )
+        # normalise component-wise; the normalised Vector cannot be
+        # re-extracted by sorting its components dict, because neither the
+        # basis terms nor the symbolic coefficients are orderable in sympy
+        magnitude_sq = sum(component**2 for component in components)
+
+        def direction(arg):
+            magnitude = sqrt(magnitude_sq.subs(index, arg))
+            return tuple(component.subs(index, arg) / magnitude for component in components)
+
+        return direction
 
     @computed_field
     def component_expressions(self) -> dict[str, str]:

--- a/lib/python/picongpu/pypicongpu/output/radiation.py
+++ b/lib/python/picongpu/pypicongpu/output/radiation.py
@@ -147,7 +147,11 @@ def _make_vector(coefficients, basis_vectors=CoordSys3D("e")):
 
 # Fixed symbol used for the (de)serialisation of index_to_direction, so that
 # the serialised form is canonical (stable symbol name) and round-trips.
-_OBSERVER_INDEX = Symbol("index")
+# The name is mangled so that it cannot collide with a user-provided direction
+# mapping that legitimately uses its own symbol named "index" (sympy interns
+# symbols by name and assumptions, so a user "index" would be the very same
+# object and get silently re-bound during deserialisation).
+_OBSERVER_INDEX = Symbol("pypicongpu_observer_index")
 
 
 def serialise_index_to_direction(value) -> dict[str, str]:
@@ -202,8 +206,10 @@ class RadiationObserverConfiguration(BaseModel):
     @field_validator("index_to_direction", mode="after")
     @classmethod
     def _validate_index_to_direction(cls, value):
-        index = Symbol("index")
-        components = [sympify(component) for component in value(index)]
+        # the mapping is evaluated at the canonical placeholder, so that a
+        # user direction that legitimately uses its own symbol named "index"
+        # is not conflated with the observer index (n1)
+        components = [sympify(component) for component in value(_OBSERVER_INDEX)]
         vec = _make_vector(components)
         if vec.magnitude().equals(1):
             return value
@@ -215,8 +221,8 @@ class RadiationObserverConfiguration(BaseModel):
         magnitude_sq = sum(component**2 for component in components)
 
         def direction(arg):
-            magnitude = sqrt(magnitude_sq.subs(index, arg))
-            return tuple(component.subs(index, arg) / magnitude for component in components)
+            magnitude = sqrt(magnitude_sq.subs(_OBSERVER_INDEX, arg))
+            return tuple(component.subs(_OBSERVER_INDEX, arg) / magnitude for component in components)
 
         return direction
 

--- a/lib/python/picongpu/pypicongpu/output/radiation.py
+++ b/lib/python/picongpu/pypicongpu/output/radiation.py
@@ -9,8 +9,16 @@ from enum import Enum
 from operator import attrgetter, itemgetter
 from typing import Annotated, Callable, Literal
 
-from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
-from sympy import Expr, Symbol
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    computed_field,
+    field_validator,
+    model_validator,
+)
+from sympy import Expr, Symbol, srepr, sympify
 from sympy.vector import CoordSys3D, Vector
 
 from picongpu.pypicongpu.output.timestepspec import TimeStepSpec
@@ -137,6 +145,46 @@ def _make_vector(coefficients, basis_vectors=CoordSys3D("e")):
     return sum((coeff * vec for coeff, vec in zip(coefficients, basis_vectors)), Vector.zero)
 
 
+# Fixed symbol used for the (de)serialisation of index_to_direction, so that
+# the serialised form is canonical (stable symbol name) and round-trips.
+_OBSERVER_INDEX = Symbol("index")
+
+
+def serialise_index_to_direction(value) -> dict[str, str]:
+    # Evaluate the direction mapping at the canonical symbol and serialise the
+    # three component expressions (lossless, via sympy's srepr).
+    # A dict (rather than a list) is used so that the value is also accepted
+    # by the rendering context checker (lists may only contain dicts).
+    return {key: srepr(component) for key, component in zip("xyz", value(_OBSERVER_INDEX))}
+
+
+def deserialise_index_to_direction(value):
+    # Rebuild the direction mapping from the serialised form (a dict of three
+    # sympy expression strings, keyed x/y/z), so that model_dump(mode="json")
+    # output can be validated again (round-trip safety). Plain numbers are
+    # turned back into python ints/floats so that re-serialisation (srepr) is
+    # stable.
+    if isinstance(value, dict) and set(value) == {"x", "y", "z"}:
+        components = []
+        for key in "xyz":
+            expr = sympify(value[key])
+            if expr.is_Integer:
+                components.append(int(expr))
+            elif expr.is_Float:
+                components.append(float(expr))
+            else:
+                components.append(expr)
+
+        def direction(arg):
+            return tuple(
+                component.subs(_OBSERVER_INDEX, arg) if isinstance(component, Expr) else component
+                for component in components
+            )
+
+        return direction
+    return value
+
+
 class RadiationObserverConfiguration(BaseModel):
     """
     observer (virtual detector) configuration for the radiation plugin
@@ -150,9 +198,14 @@ class RadiationObserverConfiguration(BaseModel):
     N_observer: Annotated[int, Field(ge=1)] = 256
     """total number of observation directions, [dimensionless]; must be >= 1"""
 
-    index_to_direction: Annotated[Callable[[Symbol], tuple[Expr, Expr, Expr]], Field(exclude=True)]
+    index_to_direction: Annotated[
+        Callable[[Symbol], tuple[Expr, Expr, Expr]],
+        BeforeValidator(deserialise_index_to_direction),
+        PlainSerializer(serialise_index_to_direction),
+    ]
     """sympy mapping from the observer index to a (nonzero, normalisable) 3D
-    direction vector; normalised to unit length during validation"""
+    direction vector; normalised to unit length during validation. Serialised
+    as the three component expressions (sympy srepr strings, keyed x/y/z)."""
 
     @field_validator("index_to_direction", mode="after")
     @classmethod

--- a/lib/python/picongpu/pypicongpu/particle_functor/particle_functor.py
+++ b/lib/python/picongpu/pypicongpu/particle_functor/particle_functor.py
@@ -8,12 +8,12 @@ License: GPLv3+
 from typing import Annotated, Literal
 from uuid import uuid4 as uuid
 
-from pydantic import BaseModel, BeforeValidator, computed_field, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, Field, computed_field, field_validator, model_validator
 
 from picongpu.pypicongpu.particle_functor.translate_to_cpp_type import translate_to_cpp_type
 from picongpu.pypicongpu.particle_functor.rng_info import RNGInfo
 from picongpu.pypicongpu.particle_functor.unit_dimension import UnitDimension
-from picongpu.pypicongpu.rendering.pmaccprinter import PMAccPrinter
+from picongpu.pypicongpu.rendering.pmaccprinter import serialise_expression
 from picongpu.pypicongpu.rendering.renderedobject import RenderedObject
 from picongpu.pypicongpu.util import alt
 from picongpu.pypicongpu.validation import validate_cpp_identifier
@@ -156,12 +156,12 @@ class ParticleFunctor(RenderedObject, BaseModel):
 
     name: str
     """name of the functor, [C++ identifier]; rendered as the C++ alias
-    `using {name} = ...` and the struct `{name}_{uuid}`, so it must be a
-    valid C++ identifier ([A-Za-z_][A-Za-z0-9_]*)"""
+    `using {name} = ...` and the struct `{name}_{typename_suffix}`, so it
+    must be a valid C++ identifier ([A-Za-z_][A-Za-z0-9_]*)"""
 
-    functor_expression: Annotated[str, BeforeValidator(PMAccPrinter().doprint)]
+    functor_expression: Annotated[str, BeforeValidator(serialise_expression)]
     """the return expression of the functor, given as a sympy expression
-    (converted to a C++ string during validation)"""
+    (converted to a C++ string during validation) or as a C++ string"""
 
     functor_preamble: list[_PreambleStatement]
     """local variable declarations executed before the return expression"""
@@ -184,9 +184,15 @@ class ParticleFunctor(RenderedObject, BaseModel):
     """the random number generator distribution used by the functor
     (uniform or normal); None if the functor is deterministic"""
 
+    typename_suffix: str = Field(default_factory=lambda: uuid().hex)
+    """stable per-instance identifier appended to the C++ type name
+    (`{name}_{typename_suffix}`); a fresh random value is drawn per instance,
+    but the value is part of the model state, so it round-trips through the
+    serialised form (the reconstructed functor keeps the same type name)"""
+
     @computed_field
     def typename(self) -> str:
-        return f"{self.name}_{uuid().hex}"
+        return f"{self.name}_{self.typename_suffix}"
 
     @model_validator(mode="after")
     def _validate(self):

--- a/lib/python/picongpu/pypicongpu/particle_functor/unit_dimension.py
+++ b/lib/python/picongpu/pypicongpu/particle_functor/unit_dimension.py
@@ -5,6 +5,8 @@ Authors: Julian Lenz
 License: GPLv3+
 """
 
+import re
+
 from pydantic import BaseModel, PrivateAttr, model_serializer, model_validator
 
 
@@ -26,6 +28,20 @@ class UnitDimension(BaseModel):
     unit_dimension: list[float] = _num_unit_dimensions.default * [0.0]
     """the seven SI base unit exponents, [dimensionless]; the vector length
     must be exactly 7 (enforced by validation)"""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _from_serialised(cls, value):
+        # accept the serialised form (the C++ std::array literal) in addition
+        # to the native list form, so that model_dump(mode="json") output can
+        # be validated again (round-trip safety)
+        if isinstance(value, str):
+            match = re.fullmatch(r"std::array<double, 7u>\{([^}]*)\}", value)
+            if match is None:
+                raise ValueError(f"Expected a serialised unit dimension. You gave: {value=}.")
+            entries = [float(entry) for entry in (e.strip() for e in match.group(1).split(",")) if entry.strip()]
+            return {"unit_dimension": entries}
+        return value
 
     @model_validator(mode="after")
     def check(self):

--- a/lib/python/picongpu/pypicongpu/rendering/pmaccprinter.py
+++ b/lib/python/picongpu/pypicongpu/rendering/pmaccprinter.py
@@ -13,6 +13,15 @@ PMACC_MATH_FUNCTIONS = {
 }
 
 
+def serialise_expression(value):
+    # Accept both sympy expressions (printed to the C++ form) and strings
+    # that are already in the C++ form, so that model_dump(mode="json")
+    # output can be validated again (round-trip safety).
+    if isinstance(value, str):
+        return value
+    return PMAccPrinter().doprint(value)
+
+
 class PMAccPrinter(cxx_code_printers["c++17"]):
     # Originally, the C++ printers use `_ns = "std::"`.
     _ns = "pmacc::math::"

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -24,6 +24,7 @@ from pydantic import (
     BeforeValidator,
     Field,
     field_serializer,
+    field_validator,
 )
 from rocrate.rocrate import ROCrate
 
@@ -200,6 +201,18 @@ class TBGFlags(BaseModel):
     @field_serializer("project_path")
     def _serialize_project_path(self, value) -> dict[str, str]:
         return {"class": "Directory", "location": str(value)}
+
+    @field_validator("project_path", mode="before")
+    @classmethod
+    def _parse_project_path(cls, value):
+        # inverse of _serialize_project_path: the serialised form is a
+        # CWL-style Directory object {"class": "Directory",
+        # "location": <path>}; accept it (and a plain str) so that
+        # model_dump(mode="json") output can be validated again (round-trip
+        # safety)
+        if isinstance(value, dict) and "location" in value:
+            return value["location"]
+        return value
 
 
 class Runner(BaseModel):

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -209,8 +209,15 @@ class TBGFlags(BaseModel):
         # CWL-style Directory object {"class": "Directory",
         # "location": <path>}; accept it (and a plain str) so that
         # model_dump(mode="json") output can be validated again (round-trip
-        # safety)
-        if isinstance(value, dict) and "location" in value:
+        # safety). A dict is only accepted if it is actually a Directory
+        # (or carries no class at all), so that unrelated dicts are not
+        # silently treated as a project path.
+        if isinstance(value, dict):
+            if value.get("class") not in (None, "Directory") or "location" not in value:
+                raise ValueError(
+                    "A serialised project path must be a CWL-style Directory object "
+                    f'(a dict with "class": "Directory" and a "location"). You gave: {value=}.'
+                )
             return value["location"]
         return value
 

--- a/lib/python/picongpu/pypicongpu/simulation.py
+++ b/lib/python/picongpu/pypicongpu/simulation.py
@@ -165,6 +165,21 @@ class Simulation(RenderedObject, BaseModel):
                 )
         return self
 
+    @field_validator("customuserinput", mode="before")
+    @classmethod
+    def _parse_custom_user_input(cls, value):
+        # accept the flattened (merged) serialised form -- a single dict with a
+        # "tags" list plus the merged rendering context -- in addition to the
+        # native list-of-entries form, so that model_dump(mode="json") output
+        # can be validated again (round-trip safety). The inverse of
+        # _render_custom_user_input_list: the merged entries are rebuilt as a
+        # single CustomUserInput, which re-serialises to the same flat form.
+        if isinstance(value, dict):
+            tags = value.get("tags")
+            context = {key: val for key, val in value.items() if key != "tags"}
+            return [CustomUserInput(tags=tags, rendering_context=context or None)]
+        return value
+
     @field_serializer("customuserinput")
     def _render_custom_user_input_list(self, value) -> dict[str, Any] | None:
         if value is None:
@@ -172,8 +187,8 @@ class Simulation(RenderedObject, BaseModel):
         custom_rendering_context = {"tags": []}
 
         for entry in value:
-            add_context = entry.get_rendering_context()
-            tags = entry.get_tags()
+            add_context = entry.rendering_context or {}
+            tags = entry.tags or []
 
             entry.check_does_not_change_existing_key_values(custom_rendering_context, add_context)
             entry.check_tags(custom_rendering_context["tags"], tags)

--- a/lib/python/picongpu/pypicongpu/species/constant/groundstateionization.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/groundstateionization.py
@@ -8,7 +8,7 @@ License: GPLv3+
 from pydantic import model_validator
 
 from .constant import Constant
-from .ionizationmodel import IonizationModel, IonizationModelGroups
+from .ionizationmodel import AnyIonizationModel, IonizationModelGroups
 
 
 class GroundStateIonization(Constant):
@@ -21,7 +21,7 @@ class GroundStateIonization(Constant):
     include/picongpu/param/speciesDefinition.param.
     """
 
-    ionization_model_list: list[IonizationModel]
+    ionization_model_list: list[AnyIonizationModel]
     """list of ground state only ionization models to apply for the species;
     must be non-empty, at most one model per ionization model group."""
 

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ADKcircularpolarization.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ADKcircularpolarization.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .ionizationmodel import IonizationModel
-from ..ionizationcurrent import IonizationCurrent
+from ..ionizationcurrent import None_
 
 
 class ADKCircularPolarization(IonizationModel):
@@ -24,5 +24,5 @@ class ADKCircularPolarization(IonizationModel):
     ionizer_picongpu_name: str = "ADKCircPol"
     """C++ Code type name of ionizer"""
 
-    ionization_current: IonizationCurrent
+    ionization_current: None_
     """ionization current implementation to use"""

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ADKlinearpolarization.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ADKlinearpolarization.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .ionizationmodel import IonizationModel
-from ..ionizationcurrent import IonizationCurrent
+from ..ionizationcurrent import None_
 
 
 class ADKLinearPolarization(IonizationModel):
@@ -24,5 +24,5 @@ class ADKLinearPolarization(IonizationModel):
     ionizer_picongpu_name: str = "ADKLinPol"
     """C++ Code type name of ionizer"""
 
-    ionization_current: IonizationCurrent
+    ionization_current: None_
     """ionization current implementation to use"""

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/BSI.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/BSI.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .ionizationmodel import IonizationModel
-from ..ionizationcurrent import IonizationCurrent
+from ..ionizationcurrent import None_
 
 
 class BSI(IonizationModel):
@@ -27,5 +27,5 @@ class BSI(IonizationModel):
     ionizer_picongpu_name: str = "BSI"
     """C++ Code type name of ionizer"""
 
-    ionization_current: IonizationCurrent
+    ionization_current: None_
     """ionization current implementation to use"""

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/BSIeffectiveZ.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/BSIeffectiveZ.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .ionizationmodel import IonizationModel
-from ..ionizationcurrent import IonizationCurrent
+from ..ionizationcurrent import None_
 
 
 class BSIEffectiveZ(IonizationModel):
@@ -22,5 +22,5 @@ class BSIEffectiveZ(IonizationModel):
     ionizer_picongpu_name: str = "BSIEffectiveZ"
     """C++ Code type name of ionizer"""
 
-    ionization_current: IonizationCurrent
+    ionization_current: None_
     """ionization current implementation to use"""

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/BSIstarkshifted.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/BSIstarkshifted.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .ionizationmodel import IonizationModel
-from ..ionizationcurrent import IonizationCurrent
+from ..ionizationcurrent import None_
 
 
 class BSIStarkShifted(IonizationModel):
@@ -21,5 +21,5 @@ class BSIStarkShifted(IonizationModel):
     ionizer_picongpu_name: str = "BSIStarkShifted"
     """C++ Code type name of ionizer"""
 
-    ionization_current: IonizationCurrent
+    ionization_current: None_
     """ionization current implementation to use"""

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/__init__.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/__init__.py
@@ -1,5 +1,5 @@
 from .ionizationmodel import IonizationModel
-from .ionizationmodelgroups import IonizationModelGroups
+from .ionizationmodelgroups import AnyIonizationModel, IonizationModelGroups
 from .BSI import BSI
 from .BSIeffectiveZ import BSIEffectiveZ
 from .BSIstarkshifted import BSIStarkShifted
@@ -10,6 +10,7 @@ from .thomasfermi import ThomasFermi
 
 __all__ = [
     "IonizationModel",
+    "AnyIonizationModel",
     "IonizationModelGroups",
     "BSI",
     "BSIEffectiveZ",

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ionizationmodel.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ionizationmodel.py
@@ -7,10 +7,10 @@ License: GPLv3+
 
 import typing
 
-from pydantic import Field
+from pydantic import ConfigDict, Field, field_validator
 
 from picongpu.pypicongpu.species.constant import Constant
-from picongpu.pypicongpu.species.constant.ionizationcurrent import IonizationCurrent
+from picongpu.pypicongpu.species.constant.ionizationcurrent import None_
 
 
 class IonizationModel(Constant):
@@ -28,6 +28,8 @@ class IonizationModel(Constant):
     include/picongpu/param/speciesDefinition.param.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     ionizer_picongpu_name: str = Field(alias="picongpu_name")
     """C++ type name of the ionizer (e.g. "BSI", "ADKLinPol"), rendered into the
     ionizers particle flag; must be a valid C++ identifier."""
@@ -37,5 +39,18 @@ class IonizationModel(Constant):
     """species to be used as the ionization electrons (rendered as a template
     argument of the ionizer)"""
 
-    ionization_current: IonizationCurrent | None = None
+    ionization_current: None_ | None = None
     """ionization current implementation to use (None = no current model)"""
+
+    @field_validator("ionization_electron_species", mode="before")
+    @classmethod
+    def _rehydrate_electron_species(cls, value):
+        # the model_dump of a species held in this (Any-typed) field is a plain
+        # dict in json mode; reconstruct the species so that the model can be
+        # used (e.g. rendered) again after a serialization round-trip.
+        # import here to avoid a circular import (species -> constants -> species)
+        if isinstance(value, dict):
+            from picongpu.pypicongpu.species.species import Species
+
+            return Species.model_validate(value)
+        return value

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ionizationmodelgroups.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/ionizationmodelgroups.py
@@ -15,7 +15,26 @@ from .thomasfermi import ThomasFermi
 from .ionizationmodel import IonizationModel
 
 import copy
-from pydantic import BaseModel
+from typing import Annotated
+
+from pydantic import BaseModel, BeforeValidator
+
+
+def _dispatch_ionization_model(value):
+    # the serialized form of an ionization model (model_dump(mode="json")) does
+    # not name the concrete class; the C++ ionizer name
+    # (ionizer_picongpu_name, alias picongpu_name) is its discriminator, as
+    # each concrete model has a distinct one. Re-attach the concrete type so
+    # that a serialized list of ionization models can be re-validated without
+    # losing the model-specific fields (round-trip safety).
+    if not isinstance(value, dict):
+        return value
+    name = value.get("ionizer_picongpu_name", value.get("picongpu_name"))
+    if name is not None:
+        for model_name, cls in _IONIZER_NAME_TO_MODEL.items():
+            if name == model_name:
+                return cls.model_validate(value)
+    return value
 
 
 class IonizationModelGroups(BaseModel):
@@ -46,3 +65,27 @@ class IonizationModelGroups(BaseModel):
                 return_dict[ionization_model] = copy.deepcopy(ionization_model_type)
 
         return return_dict
+
+
+# the C++ ionizer name (the default of ionizer_picongpu_name) -> model class,
+# for all concrete ionization models
+_IONIZER_NAME_TO_MODEL: dict[str, type[IonizationModel]] = {
+    ionization_model.model_fields["ionizer_picongpu_name"].default: ionization_model
+    for ionization_model in (
+        BSI,
+        BSIEffectiveZ,
+        BSIStarkShifted,
+        ADKLinearPolarization,
+        ADKCircularPolarization,
+        Keldysh,
+        ThomasFermi,
+    )
+}
+
+AnyIonizationModel = Annotated[
+    BSI | BSIEffectiveZ | BSIStarkShifted | ADKLinearPolarization | ADKCircularPolarization | Keldysh | ThomasFermi,
+    BeforeValidator(_dispatch_ionization_model),
+]
+"""union of all concrete ionization models, with a before validator that
+re-attaches the concrete class from the serialized ionizer name (round-trip
+safety)"""

--- a/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/keldysh.py
+++ b/lib/python/picongpu/pypicongpu/species/constant/ionizationmodel/keldysh.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from .ionizationmodel import IonizationModel
-from ..ionizationcurrent import IonizationCurrent
+from ..ionizationcurrent import None_
 
 
 class Keldysh(IonizationModel):
@@ -25,5 +25,5 @@ class Keldysh(IonizationModel):
     ionizer_picongpu_name: str = "Keldysh"
     """C++ Code type name of ionizer"""
 
-    ionization_current: IonizationCurrent
+    ionization_current: None_
     """ionization current implementation to use"""

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/free_formula.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/free_formula.py
@@ -7,9 +7,9 @@ License: GPLv3+
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
-from ....rendering.pmaccprinter import PMAccPrinter
+from ....rendering.pmaccprinter import serialise_expression
 
 
 class FreeFormula(BaseModel):
@@ -25,8 +25,13 @@ class FreeFormula(BaseModel):
     Units policy: the expression must evaluate to a number density, [m^-3].
     """
 
+    # accept both the field name (as produced by model_dump) and the alias
+    # (density_expression) upon construction, so that serialised output can be
+    # validated again (round-trip safety)
+    model_config = ConfigDict(populate_by_name=True)
+
     type_freeformula: Literal[True] = True
     """discriminator for the AnyDensityProfile union."""
 
-    function_body: Annotated[str, BeforeValidator(PMAccPrinter().doprint)] = Field(alias="density_expression")
+    function_body: Annotated[str, BeforeValidator(serialise_expression)] = Field(alias="density_expression")
     """C++ expression computing the local number density, [m^-3] (sympy expression or string)."""

--- a/lib/python/picongpu/pypicongpu/species/operation/densityprofile/gaussian.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/densityprofile/gaussian.py
@@ -6,7 +6,7 @@ License: GPLv3+
 """
 
 from typing import Annotated, Literal
-from pydantic import AfterValidator, BaseModel, Field, model_validator
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, model_validator
 
 
 def neq_0(value):
@@ -29,6 +29,11 @@ class Gaussian(BaseModel):
 
     Units policy: SI (m^-3 for densities, m for positions/sigmas).
     """
+
+    # accept both the field names (as produced by model_dump) and the aliases
+    # (e.g. center_front) upon construction, so that serialised output can be
+    # validated again (round-trip safety)
+    model_config = ConfigDict(populate_by_name=True)
 
     type_gaussian: Literal[True] = True
     """discriminator for the AnyDensityProfile union."""

--- a/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
@@ -69,9 +69,17 @@ class SimpleDensity(BaseModel):
             # proper error instead of failing with an AttributeError here
             raise ValueError(f"species must be a list of Species. You gave: {species=}.")
         species = [Species.model_validate(entry) if isinstance(entry, dict) else entry for entry in species]
+        # the tie-break on name makes the order a pure function of the
+        # species (not of set iteration order, which depends on the
+        # per-process string hash seed and the insertion order), so that
+        # the serialised form is deterministic and re-serialisation is
+        # stable (round-trip safety)
         return sorted(
             set(species),
-            key=lambda species: 0 if species.constants.density_ratio is None else species.constants.density_ratio.ratio,
+            key=lambda species: (
+                0 if species.constants.density_ratio is None else species.constants.density_ratio.ratio,
+                species.name,
+            ),
         )
 
     @computed_field

--- a/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
+++ b/lib/python/picongpu/pypicongpu/species/operation/simpledensity.py
@@ -7,7 +7,7 @@ License: GPLv3+
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, computed_field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
 
 from ..species import Species
 from .densityprofile import AnyDensityProfile
@@ -45,9 +45,30 @@ class SimpleDensity(BaseModel):
     type_simpledensity: Literal[True] = True
     """discriminator for the AnyOperation union."""
 
+    @model_validator(mode="before")
+    @classmethod
+    def _reconstruct_species(cls, data):
+        # `species` is excluded from the serialised form; instead, the computed
+        # fields placed_species_initial / placed_species_copied are dumped.
+        # Rebuild the species list from them so that model_dump(mode="json")
+        # output can be validated again (round-trip safety).
+        if isinstance(data, dict) and "species" not in data and data.get("placed_species_initial") is not None:
+            copied = data.get("placed_species_copied") or []
+            data = {
+                **data,
+                "species": [Species.model_validate(data["placed_species_initial"])]
+                + [Species.model_validate(entry) for entry in copied],
+            }
+        return data
+
     @field_validator("species", mode="before")
     @classmethod
     def validate_species(cls, species):
+        if not isinstance(species, list):
+            # let the field type validation (or the containing union) report a
+            # proper error instead of failing with an AttributeError here
+            raise ValueError(f"species must be a list of Species. You gave: {species=}.")
+        species = [Species.model_validate(entry) if isinstance(entry, dict) else entry for entry in species]
         return sorted(
             set(species),
             key=lambda species: 0 if species.constants.density_ratio is None else species.constants.density_ratio.ratio,

--- a/lib/python/picongpu/pypicongpu/species/util/element.py
+++ b/lib/python/picongpu/pypicongpu/species/util/element.py
@@ -9,7 +9,7 @@ import re
 
 import periodictable
 import scipy
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, computed_field, model_validator
 
 from picongpu.pypicongpu.rendering import RenderedObject
 
@@ -29,7 +29,25 @@ class Element(RenderedObject, BaseModel):
     To describe atoms/ions you also need to initialize the charge_state of the species.
     """
 
+    openpmd_name: str
+    """(case-sensitive) chemical/nuclear element symbol (e.g. "H", "He",
+    "#2H"); source of truth for the periodic table lookup, kept as a field so
+    that the element (including isotope/mass number) survives a
+    serialization round-trip"""
+
     _store: periodictable.core.Element | None = None
+
+    @model_validator(mode="after")
+    def _lookup_element(self):
+        mass_number, symbol = Element.parse_openpmd_isotopes(self.openpmd_name)
+
+        # search for symbol in periodic table
+        for element in periodictable.elements:
+            if symbol == element.symbol:
+                self._store = element if mass_number is None else element[mass_number]
+                return self
+
+        raise NameError(f"unknown element: {symbol}")
 
     @staticmethod
     def parse_openpmd_isotopes(openpmd_name: str) -> tuple[int | None, str]:
@@ -58,31 +76,6 @@ class Element(RenderedObject, BaseModel):
                 if openpmd_name not in ["n"]:
                     return True
         return False
-
-    def __init__(self, openpmd_name: str) -> None:
-        """
-        get the correct substance implementation from a openPMD type name
-
-        @param openpmd_name (case-sensitive) chemical/nuclear element symbols (e.g. "H", "D", "He", "N").
-
-        :return: object representing the given species
-        """
-        BaseModel.__init__(self)
-
-        mass_number, openpmd_name = Element.parse_openpmd_isotopes(openpmd_name)
-
-        found = False
-        # search for name in periodic table
-        for element in periodictable.elements:
-            if openpmd_name == element.symbol:
-                if mass_number is None:
-                    self._store = element
-                else:
-                    self._store = element[mass_number]
-                found = True
-
-        if not found:
-            raise NameError(f"unknown element: {openpmd_name}")
 
     def get_picongpu_name(self) -> str:
         """

--- a/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
@@ -669,3 +669,10 @@ def test_collision_setup_roundtrips_and_renders_identically():
         Runner(sim=restored_sim, setup_dir=setup2, run_dir=Path(tmp) / "run2").generate()
         _assert_same_tree(setup / "include", setup2 / "include")
         _assert_same_tree(setup / "etc", setup2 / "etc")
+
+
+def test_collision_functor_malformed_dict_raises_value_error():
+    # a malformed serialised functor (type_constlog without data.coulomb_log)
+    # must fail with a validation-style error, not a raw KeyError
+    with pytest.raises(ValueError, match="data.coulomb_log"):
+        Collision(species_pairs=[(_ELECTRON, _ELECTRON)], functor={"type_constlog": True, "data": {}})

--- a/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
@@ -32,6 +32,8 @@ import pytest
 from sympy import Symbol
 
 from picongpu import picmi
+from picongpu.picmi.interaction import Collision as PicmiCollision
+from picongpu.picmi.interaction import CollisionalPhysicsSetup as PicmiCollisionalPhysicsSetup
 from picongpu.pypicongpu.runner import Runner
 from picongpu.pypicongpu.simulation import Simulation
 from picongpu.pypicongpu.collisions import (
@@ -599,3 +601,68 @@ def test_runner_roundtrips_from_runner_metadata():
     restored = Runner.model_validate(runner_json)
     assert isinstance(restored, Runner)
     assert isinstance(restored.sim, Simulation)
+
+
+def _collision_sim():
+    # a representative simulation whose collisional physics carries a real
+    # (constant-log) collision, built through the picmi interaction API
+    grid = picmi.Cartesian3DGrid(
+        number_of_cells=[16, 16, 16],
+        lower_bound=[0, 0, 0],
+        upper_bound=[1e-5, 1e-5, 1e-5],
+        lower_boundary_conditions=["periodic", "periodic", "periodic"],
+        upper_boundary_conditions=["periodic", "periodic", "periodic"],
+    )
+    solver = picmi.ElectromagneticSolver(method="Yee", grid=grid)
+    sim = picmi.Simulation(time_step_size=1e-15, max_steps=100, solver=solver)
+
+    profile = picmi.UniformDistribution(density=42, rms_velocity=[1e5, 0, 0], directed_velocity=[1e5, 0, 0])
+    electron = picmi.Species(name="electron", mass=9.109e-31, charge=-1.602e-19, initial_distribution=profile)
+    hydrogen = picmi.Species(name="hydrogen", mass=1.67e-27, charge=1.602e-19, initial_distribution=profile)
+    sim.add_species(electron, picmi.PseudoRandomLayout(n_macroparticles_per_cell=4))
+    sim.add_species(hydrogen, picmi.PseudoRandomLayout(n_macroparticles_per_cell=2))
+
+    sim.picongpu_interaction = [
+        PicmiCollisionalPhysicsSetup(
+            collisions=[
+                PicmiCollision(species_pairs=[(electron, hydrogen)], functor=picmi.ConstLogCollision(coulomb_log=12.0))
+            ]
+        )
+    ]
+    return sim
+
+
+def _assert_same_tree(a: Path, b: Path):
+    files_a = {p.relative_to(a) for p in a.rglob("*") if p.is_file()}
+    files_b = {p.relative_to(b) for p in b.rglob("*") if p.is_file()}
+    assert files_a == files_b, f"file sets differ between {a} and {b}: {files_a ^ files_b}"
+    for rel in files_a:
+        assert (a / rel).read_bytes() == (b / rel).read_bytes(), f"rendered file differs: {rel}"
+
+
+def test_collision_setup_roundtrips_and_renders_identically():
+    # end-to-end collision regression: a setup containing a real collision must
+    # generate at all (the rendering-context schema check used to reject the
+    # serialised species_pairs shape before any artifact was written), both
+    # metadata JSONs must reload into re-serialising-identical instances, and a
+    # regeneration from the reconstructed simulation must render a
+    # byte-identical include/ + etc/ tree
+    sim = _collision_sim()
+    with tempfile.TemporaryDirectory() as tmp:
+        setup = Path(tmp) / "setup"
+        sim.write_input_file(setup)
+        context = json.loads((setup / "metadata" / "pypicongpu_rendering_context.json").read_text())
+        runner_json = json.loads((setup / "metadata" / "pypicongpu_runner.json").read_text())
+
+        restored_sim = Simulation.model_validate(context)
+        assert restored_sim.model_dump(mode="json") == context
+
+        restored_runner = Runner.model_validate(runner_json)
+        assert isinstance(restored_runner, Runner)
+        assert isinstance(restored_runner.sim, Simulation)
+        assert restored_runner.model_dump(mode="json") == runner_json
+
+        setup2 = Path(tmp) / "setup2"
+        Runner(sim=restored_sim, setup_dir=setup2, run_dir=Path(tmp) / "run2").generate()
+        _assert_same_tree(setup / "include", setup2 / "include")
+        _assert_same_tree(setup / "etc", setup2 / "etc")

--- a/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
@@ -274,7 +274,7 @@ def _build(name: str):
     if name == "BinningAxis":
         return BinningAxis(
             name="x",
-            bin_spec=BinSpec(kind="Linear", start=0, stop=10, nsteps=10),
+            bin_spec_raw=BinSpec(kind="Linear", start=0, stop=10, nsteps=10),
             functor=_FUNCTOR,
             use_overflow_bins=True,
         )
@@ -285,7 +285,7 @@ def _build(name: str):
             axes=[
                 BinningAxis(
                     name="x",
-                    bin_spec=BinSpec(kind="Linear", start=0, stop=10, nsteps=10),
+                    bin_spec_raw=BinSpec(kind="Linear", start=0, stop=10, nsteps=10),
                     functor=_FUNCTOR,
                     use_overflow_bins=True,
                 )

--- a/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
@@ -601,6 +601,9 @@ def test_runner_roundtrips_from_runner_metadata():
     restored = Runner.model_validate(runner_json)
     assert isinstance(restored, Runner)
     assert isinstance(restored.sim, Simulation)
+    # the re-serialisation contract: the reconstructed runner must dump
+    # identically to the on-disk metadata (same as the Simulation counterpart)
+    assert restored.model_dump(mode="json") == runner_json
 
 
 def _collision_sim():

--- a/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
@@ -4,140 +4,512 @@ Copyright 2026 PIConGPU contributors
 Authors: Julian Lenz
 License: GPLv3+
 
-Round-trip safety (task 06): every model's own serialised output
-(``model_dump(mode="json")``) must be accepted again by the model's
-constructor, and re-serialising the reconstructed instance must yield the
-identical dump. This guarantees that the (machine-readable) constraints and
-validators captured in the pydantic models do not reject the models' own
-serialisation, so that downstream tooling (e.g. task 07) can validate
-``model_dump(mode="json")`` output against the models.
+Round-trip safety (task 07): a model's serialised output
+(``model_dump(mode="json")``) must be accepted again by the model, and
+re-serialising the reconstructed instance must yield the identical dump.
 
-Only models whose serialisation is field-preserving are covered here; models
-with a custom top-level ``model_serializer`` (e.g. the openPMD plugin) are
-covered by the rendered-output regression instead.
+This is checked with ``model_validate`` -- the canonical "reconstruct a valid
+instance from on-disk serialised JSON" path -- so that the (machine-readable)
+constraints and validators captured in the pydantic models do not reject the
+models' own serialisation, and so that a full ``Runner``/``Simulation`` can be
+rebuilt from the metadata JSONs written during ``generate()``.
+
+The corpus covers every model whose serialisation is field-preserving, as well
+as the models that needed (de)serialisation fixes to become lossless
+(solvers, lasers, openPMD plugin, binning, elements, ionization models,
+collisions, radiation observer, operations, ...). Models whose top-level
+``model_serializer`` produces a rendering-oriented form (e.g. the openPMD
+plugin) are covered both here (their ``model_dump`` now carries the full state)
+and by the rendered-output regression.
 """
 
 from datetime import timedelta
+from pathlib import Path
+import json
+import tempfile
 
 import pytest
+from sympy import Symbol
 
-from picongpu.pypicongpu.collisions import CollisionNumericsConfig, ConstLogCollision
-from picongpu.pypicongpu.field_solver import YeeSolver
-from picongpu.pypicongpu.laser import DispersivePulseLaser
+from picongpu import picmi
+from picongpu.pypicongpu.runner import Runner
+from picongpu.pypicongpu.simulation import Simulation
+from picongpu.pypicongpu.collisions import (
+    Collision,
+    CollisionNumericsConfig,
+    CollisionalPhysicsSetup,
+    ConstLogCollision,
+    DynamicLogCollision,
+)
+from picongpu.pypicongpu.customuserinput import CustomUserInput
+from picongpu.pypicongpu.field_solver import LeheSolver, YeeSolver
+from picongpu.pypicongpu.grid import BoundaryCondition, Grid3D
+from picongpu.pypicongpu.laser import (
+    DispersivePulseLaser,
+    FromOpenPMDPulseLaser,
+    GaussianLaser,
+    PlaneWaveLaser,
+    TWTSLaser,
+)
 from picongpu.pypicongpu.movingwindow import MovingWindow
+from picongpu.pypicongpu.output.binning import Binning, BinningAxis, BinSpec
+from picongpu.pypicongpu.output.checkpoint import Checkpoint
+from picongpu.pypicongpu.output.energy_histogram import EnergyHistogram
+from picongpu.pypicongpu.output.openpmd_plugin import FieldDump, OpenPMDConfig, OpenPMDPlugin, RangeSpec
+from picongpu.pypicongpu.output.phase_space import PhaseSpace
+from picongpu.pypicongpu.output.radiation import (
+    LinearFrequencies,
+    LogFrequencies,
+    RadiationConfiguration,
+    RadiationObserverConfiguration,
+    RadiationPlugin,
+    RadiationPluginConfig,
+)
 from picongpu.pypicongpu.output.timestepspec import Spec, TimeStepSpec
-from picongpu.pypicongpu.species.operation.momentum import Temperature
+from picongpu.pypicongpu.particle_functor.filtered_species import FilteredSpecies
+from picongpu.pypicongpu.particle_functor.particle_functor import ParticleFunctor
+from picongpu.pypicongpu.particle_functor.rng_info import NormalRNGInfo
+from picongpu.pypicongpu.species.attribute import BoundElectrons, Momentum, Position, Weighting
+from picongpu.pypicongpu.species.constant import Charge, DensityRatio, ElementProperties, GroundStateIonization, Mass
+from picongpu.pypicongpu.species.constant.ionizationcurrent import None_ as NoCurrent
+from picongpu.pypicongpu.species.constant.ionizationmodel import (
+    ADKCircularPolarization,
+    ADKLinearPolarization,
+    BSI,
+    BSIEffectiveZ,
+    BSIStarkShifted,
+    Keldysh,
+    ThomasFermi,
+)
+from picongpu.pypicongpu.species.constant.synchrotron import SynchrotronConstant, SynchrotronParams
+from picongpu.pypicongpu.species.operation import SetChargeState, SimpleDensity, SimpleMomentum
+from picongpu.pypicongpu.species.operation.densityprofile import Cylinder, Foil, FreeFormula, Uniform
+from picongpu.pypicongpu.species.operation.densityprofile.gaussian import Gaussian
+from picongpu.pypicongpu.species.operation.densityprofile.plasmaramp import Exponential
+from picongpu.pypicongpu.species.operation.layout import OnePosition, Quiet, Random
+from picongpu.pypicongpu.species.operation.momentum import Drift, Temperature
+from picongpu.pypicongpu.species.species import Species
+from picongpu.pypicongpu.species.util.element import Element
 from picongpu.pypicongpu.walltime import Walltime
 
-from .model_factories import (
-    base_laser_kwargs,
-    make_energy_histogram,
-    make_from_openpmd_laser,
-    make_grid,
-    make_laser,
-    make_phase_space,
-    make_plane_wave_laser,
-    make_species,
-    make_twts_laser,
+# shared building blocks -----------------------------------------------------
+
+_LASER_KWARGS = dict(
+    propagation_direction=(0.0, 1.0, 0.0),
+    polarization_direction=(0.0, 0.0, 1.0),
+    polarization_type="Linear",
+    wave_length_si=0.8e-6,
+    pulse_duration_si=1e-15,
+    focus_pos_si=(0.5e-5, 0.5e-5, 0.5e-5),
+    phase=0.0,
+    E0_si=1e10,
+    pulse_init=1.0,
+    huygens_surface_positions=[[1, -1], [1, -1], [1, -1]],
+)
+
+_ELECTRON = Species(
+    name="electron",
+    constants=[Mass(mass_si=9.109e-31), Charge(charge_si=-1.602e-19)],
+    attributes=[Position(), Weighting(), Momentum()],
+)
+
+_ION = Species(
+    name="hydrogen",
+    constants=[
+        Mass(mass_si=1.67e-27),
+        Charge(charge_si=1.602e-19),
+        ElementProperties(element=Element(openpmd_name="H")),
+        GroundStateIonization(
+            ionization_model_list=[BSI(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON)]
+        ),
+    ],
+    attributes=[Position(), Weighting(), Momentum(), BoundElectrons()],
+)
+
+_TSS = TimeStepSpec([Spec(start=0, stop=-1, step=10)])
+
+_FUNCTOR = ParticleFunctor(
+    name="gammaFilter",
+    functor_expression=Symbol("px") ** 2 + Symbol("py") ** 2,
+    functor_preamble=[],
+    return_type="float_X",
 )
 
 
 def _build(name: str):
     if name == "Grid3D":
-        return make_grid()
+        return Grid3D(
+            cell_size_si=(1e-6, 1e-6, 1e-6),
+            cell_cnt=(16, 16, 16),
+            boundary_condition=(BoundaryCondition.PERIODIC,) * 3,
+            n_gpus=(1, 1, 1),
+            super_cell_size=(2, 2, 2),
+        )
     if name == "Walltime":
-        return Walltime(walltime=timedelta(hours=1))
+        return Walltime(walltime=timedelta(hours=1, minutes=2, seconds=3))
     if name == "MovingWindow":
-        return MovingWindow(move_point=0.5, stop_iteration=50)
+        return MovingWindow(move_point=0.5, stop_iteration=100)
     if name == "YeeSolver":
         return YeeSolver()
+    if name == "LeheSolver":
+        return LeheSolver()
     if name == "GaussianLaser":
-        return make_laser()
+        return GaussianLaser(waist_si=1e-5, laguerre_modes=[1.0], laguerre_phases=[0.0], **_LASER_KWARGS)
     if name == "PlaneWaveLaser":
-        return make_plane_wave_laser()
+        return PlaneWaveLaser(laser_nofocus_constant_si=1.0, **_LASER_KWARGS)
     if name == "DispersivePulseLaser":
         return DispersivePulseLaser(
-            **(
-                base_laser_kwargs()
-                | dict(waist=1e-5, spectral_support=2.0, sd_si=0.0, ad_si=0.0, gdd_si=0.0, tod_si=0.0)
-            )
+            waist_si=1e-5, spectral_support=1.0, sd_si=1e-29, ad_si=1e-28, gdd_si=1e-27, tod_si=1e-26, **_LASER_KWARGS
         )
     if name == "TWTSLaser":
-        return make_twts_laser()
+        return TWTSLaser(
+            waist_si=1e-5,
+            laserIncidenceAngle=0.1,
+            laserIncidenceAnglePositive=True,
+            polarizationAngle=0.2,
+            beta0=1.0,
+            time_offset_si=0.0,
+            focus_lateral_offset_si=0.0,
+            windowStart=0.0,
+            windowEnd=0.0,
+            windowLength=0.0,
+            **_LASER_KWARGS,
+        )
     if name == "FromOpenPMDPulseLaser":
-        return make_from_openpmd_laser()
+        return FromOpenPMDPulseLaser(
+            propagation_direction=(0.0, 1.0, 0.0),
+            polarization_direction=(0.0, 0.0, 1.0),
+            file_path="pulse.h5",
+            iteration=0,
+            dataset_name="E",
+            datatype="E_Cell",
+            time_offset_si=0.0,
+            polarisationAxisOpenPMD="x",
+            propagationAxisOpenPMD="y",
+            huygens_surface_positions=[[1, -1], [1, -1], [1, -1]],
+        )
+    if name == "Spec_full":
+        return Spec(start=0, stop=-1, step=10)
+    if name == "Spec_opt":
+        return Spec(start=None, stop=None, step=None)
     if name == "TimeStepSpec":
-        return TimeStepSpec([Spec(start=0, stop=-1, step=10)])
+        return _TSS
     if name == "Checkpoint":
-        from picongpu.pypicongpu.output.checkpoint import Checkpoint
-
-        return Checkpoint(period=TimeStepSpec([Spec(start=0, stop=-1, step=10)]))
+        return Checkpoint(period=_TSS)
+    if name == "Checkpoint_timePeriod":
+        return Checkpoint(timePeriod=5)
     if name == "LinearFrequencies":
-        from picongpu.pypicongpu.output.radiation import LinearFrequencies
-
         return LinearFrequencies()
+    if name == "LogFrequencies":
+        return LogFrequencies(omega_min=1e14, omega_max=1e17)
+    if name == "RadiationObserverConfiguration":
+        return RadiationObserverConfiguration(index_to_direction=lambda _: [1, 0, 0], N_observer=1)
     if name == "RadiationConfiguration":
-        from picongpu.pypicongpu.output.radiation import RadiationConfiguration
-
-        return RadiationConfiguration()
+        return RadiationConfiguration(frequencies=LogFrequencies(omega_min=1e14, omega_max=1e17))
+    if name == "RadiationPluginConfig":
+        return RadiationPluginConfig(
+            observer=RadiationObserverConfiguration(index_to_direction=lambda _: [1, 0, 0], N_observer=1)
+        )
+    if name == "RadiationPlugin":
+        return RadiationPlugin(
+            config=RadiationPluginConfig(
+                observer=RadiationObserverConfiguration(index_to_direction=lambda _: [1, 0, 0], N_observer=1)
+            ),
+            species=[_ELECTRON],
+            period=TimeStepSpec([Spec(start=10, stop=-1, step=100)]),
+        )
     if name == "PhaseSpace":
-        return make_phase_space()
+        return PhaseSpace(
+            species=_ELECTRON,
+            period=_TSS,
+            spatial_coordinate="x",
+            momentum_coordinate="px",
+            min_momentum=-1.0,
+            max_momentum=1.0,
+        )
     if name == "EnergyHistogram":
-        return make_energy_histogram()
+        return EnergyHistogram(
+            species=_ELECTRON,
+            period=_TSS,
+            bin_count=16,
+            min_energy=0.0,
+            max_energy=100.0,
+        )
+    if name == "FieldDump_native":
+        return FieldDump(name="gamma", functor=None, filtername=None)
+    if name == "ParticleFunctor":
+        return _FUNCTOR
+    if name == "FieldDump_derived":
+        return FieldDump(name="derivedField", functor=_FUNCTOR)
+    if name == "FilteredSpecies":
+        return FilteredSpecies(species=_ELECTRON, functor=_FUNCTOR)
+    if name == "ParticleFunctor_rng":
+        return ParticleFunctor(
+            name="randomFunctor",
+            functor_expression=Symbol("px") * 2,
+            functor_preamble=[],
+            return_type="float_X",
+            rng_info=NormalRNGInfo(return_type="float_X"),
+        )
+    if name == "OpenPMDConfig":
+        return OpenPMDConfig(file="simData", range=[None, 42, (1, 10)])
+    if name == "RangeSpec":
+        return RangeSpec()
+    if name == "OpenPMDPlugin":
+        return OpenPMDPlugin(
+            sources=[
+                (_TSS, _ELECTRON),
+                (_TSS, FieldDump(name="derivedField", functor=_FUNCTOR)),
+                (_TSS, FilteredSpecies(species=_ELECTRON, functor=_FUNCTOR)),
+            ],
+            config=OpenPMDConfig(file="simData"),
+        )
+    if name == "BinSpec":
+        return BinSpec(kind="Linear", start=0, stop=10, nsteps=10)
+    if name == "BinningAxis":
+        return BinningAxis(
+            name="x",
+            bin_spec=BinSpec(kind="Linear", start=0, stop=10, nsteps=10),
+            functor=_FUNCTOR,
+            use_overflow_bins=True,
+        )
+    if name == "Binning":
+        return Binning(
+            name="binner",
+            deposition_functor=_FUNCTOR,
+            axes=[
+                BinningAxis(
+                    name="x",
+                    bin_spec=BinSpec(kind="Linear", start=0, stop=10, nsteps=10),
+                    functor=_FUNCTOR,
+                    use_overflow_bins=True,
+                )
+            ],
+            species=[_ELECTRON, FilteredSpecies(species=_ELECTRON, functor=_FUNCTOR)],
+            period=_TSS,
+            openPMDBackendConfig={"some": "config"},
+            openPMDExt="h5",
+            openPMDInfix="_%06T",
+            dumpPeriod=10,
+        )
     if name == "ConstLogCollision":
         return ConstLogCollision(coulomb_log=12.0)
+    if name == "DynamicLogCollision":
+        return DynamicLogCollision()
+    if name == "Collision":
+        return Collision(species_pairs=[(_ELECTRON, _ION)], functor=ConstLogCollision(coulomb_log=12.0))
+    if name == "Collision_filters":
+        return Collision(
+            species_pairs=[(FilteredSpecies(species=_ELECTRON, functor=_FUNCTOR), _ION)], functor=DynamicLogCollision()
+        )
     if name == "CollisionNumericsConfig":
         return CollisionNumericsConfig(precision=64, cell_list_chunk_size=128)
+    if name == "CollisionalPhysicsSetup":
+        return CollisionalPhysicsSetup(
+            collisions=[
+                Collision(
+                    species_pairs=[(_ELECTRON, _ION), (_ELECTRON, _ELECTRON)],
+                    functor=ConstLogCollision(coulomb_log=12.0),
+                )
+            ],
+            screening_species=[_ELECTRON, _ION, FilteredSpecies(species=_ELECTRON, functor=_FUNCTOR)],
+            numerics_config=CollisionNumericsConfig(),
+        )
     if name == "Species":
-        return make_species()
-    if name == "OnePosition":
-        from picongpu.pypicongpu.species.operation.layout import OnePosition
-
-        return OnePosition(ppc=2, in_cell_offset=(0.5, 0.5, 0.5))
-    if name == "Quiet":
-        from picongpu.pypicongpu.species.operation.layout import Quiet
-
-        return Quiet(ppc=8, n_points=(2, 2, 2))
+        return _ELECTRON
+    if name == "Species_ion":
+        return _ION
+    if name == "Position":
+        return Position()
+    if name == "Weighting":
+        return Weighting()
+    if name == "Momentum":
+        return Momentum()
+    if name == "BoundElectrons":
+        return BoundElectrons()
+    if name == "Mass":
+        return Mass(mass_si=9.109e-31)
+    if name == "Charge":
+        return Charge(charge_si=-1.602e-19)
+    if name == "DensityRatio":
+        return DensityRatio(ratio=2.0)
+    if name == "Element":
+        return Element(openpmd_name="H")
+    if name == "Element_isotope":
+        return Element(openpmd_name="#14N")
+    if name == "ElementProperties":
+        return ElementProperties(element=Element(openpmd_name="H"))
+    if name == "SynchrotronConstant":
+        return SynchrotronConstant(photon_species=_ELECTRON)
+    if name == "SynchrotronParams":
+        return SynchrotronParams()
+    if name == "NoCurrent":
+        return NoCurrent()
+    if name == "BSI":
+        return BSI(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON)
+    if name == "BSIEffectiveZ":
+        return BSIEffectiveZ(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON)
+    if name == "BSIStarkShifted":
+        return BSIStarkShifted(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON)
+    if name == "ADKLinearPolarization":
+        return ADKLinearPolarization(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON)
+    if name == "ADKCircularPolarization":
+        return ADKCircularPolarization(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON)
+    if name == "Keldysh":
+        return Keldysh(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON)
+    if name == "ThomasFermi":
+        return ThomasFermi(ionization_electron_species=_ELECTRON)
+    if name == "GroundStateIonization":
+        return GroundStateIonization(
+            ionization_model_list=[
+                BSI(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON),
+                ADKLinearPolarization(ionization_current=NoCurrent(), ionization_electron_species=_ELECTRON),
+                ThomasFermi(ionization_electron_species=_ELECTRON),
+            ]
+        )
+    if name == "SimpleDensity":
+        return SimpleDensity(profile=Uniform(density_si=42.0), species=[_ELECTRON, _ION], layout=Random(ppc=4))
+    if name == "SimpleMomentum":
+        return SimpleMomentum(
+            species=_ELECTRON, temperature=Temperature(temperature_kev=1e4), drift=Drift.from_velocity((1e5, 0, 0))
+        )
+    if name == "SetChargeState":
+        return SetChargeState(species=_ION, charge_state=1)
+    if name == "Uniform":
+        return Uniform(density_si=42.0)
+    if name == "Foil":
+        return Foil(density_si=42.0, y_value_front_foil_si=0.0, thickness_foil_si=1e-6)
+    if name == "Gaussian_profile":
+        return Gaussian(
+            center_front=0.0,
+            center_rear=1e-6,
+            sigma_front=1e-7,
+            sigma_rear=1e-7,
+            factor=-1.0,
+            power=2.0,
+            vacuum_cells_front=0,
+            density=42.0,
+        )
+    if name == "Cylinder":
+        return Cylinder(
+            density_si=42.0,
+            radius_si=1e-6,
+            center_position_si=(0.0, 0.5, 0.5),
+            cylinder_axis=(0.0, 1.0, 0.0),
+        )
+    if name == "FreeFormula":
+        return FreeFormula(density_expression="x")
+    if name == "Exponential_ramp":
+        return Exponential(PlasmaLength=1e-6, PlasmaCutoff=0.0)
     if name == "Random":
-        from picongpu.pypicongpu.species.operation.layout import Random
-
         return Random(ppc=4)
+    if name == "Quiet":
+        return Quiet(ppc=8, n_points=(2, 2, 2))
+    if name == "OnePosition":
+        return OnePosition(ppc=2, in_cell_offset=(0.5, 0.5, 0.5))
     if name == "Drift":
-        from picongpu.pypicongpu.species.operation.momentum import Drift
-
-        return Drift.from_velocity((1e5, 0.0, 0.0))
+        return Drift.from_velocity((1e5, 0, 0))
     if name == "Temperature_kev":
         return Temperature(temperature_kev=1e4)
     if name == "Temperature_directional":
         return Temperature(temperature_kev_directional=(1.0, 2.0, 3.0))
+    if name == "CustomUserInput":
+        cu = CustomUserInput()
+        cu.addToCustomInput({"test_data_1": 1}, "tag_1")
+        return cu
     raise AssertionError(f"unknown round-trip candidate {name=}")
 
 
 _MODELS = [
+    # grid / window / time
     "Grid3D",
     "Walltime",
     "MovingWindow",
+    "Spec_full",
+    "Spec_opt",
+    "TimeStepSpec",
+    # solvers
     "YeeSolver",
+    "LeheSolver",
+    # lasers
     "GaussianLaser",
     "PlaneWaveLaser",
     "DispersivePulseLaser",
     "TWTSLaser",
     "FromOpenPMDPulseLaser",
-    "TimeStepSpec",
-    "Checkpoint",
+    # radiation
     "LinearFrequencies",
+    "LogFrequencies",
+    "RadiationObserverConfiguration",
     "RadiationConfiguration",
+    "RadiationPluginConfig",
+    "RadiationPlugin",
+    # plugins / diagnostics
+    "Checkpoint",
+    "Checkpoint_timePeriod",
     "PhaseSpace",
     "EnergyHistogram",
+    "FieldDump_native",
+    "ParticleFunctor",
+    "ParticleFunctor_rng",
+    "FieldDump_derived",
+    "FilteredSpecies",
+    "OpenPMDConfig",
+    "RangeSpec",
+    "OpenPMDPlugin",
+    "BinSpec",
+    "BinningAxis",
+    "Binning",
+    # collisions
     "ConstLogCollision",
+    "DynamicLogCollision",
+    "Collision",
+    "Collision_filters",
     "CollisionNumericsConfig",
+    "CollisionalPhysicsSetup",
+    # species / attributes / constants
     "Species",
-    "OnePosition",
-    "Quiet",
+    "Species_ion",
+    "Position",
+    "Weighting",
+    "Momentum",
+    "BoundElectrons",
+    "Mass",
+    "Charge",
+    "DensityRatio",
+    "Element",
+    "Element_isotope",
+    "ElementProperties",
+    "SynchrotronConstant",
+    "SynchrotronParams",
+    "NoCurrent",
+    # ionization models
+    "BSI",
+    "BSIEffectiveZ",
+    "BSIStarkShifted",
+    "ADKLinearPolarization",
+    "ADKCircularPolarization",
+    "Keldysh",
+    "ThomasFermi",
+    "GroundStateIonization",
+    # operations
+    "SimpleDensity",
+    "SimpleMomentum",
+    "SetChargeState",
+    "Uniform",
+    "Foil",
+    "Gaussian_profile",
+    "Cylinder",
+    "FreeFormula",
+    "Exponential_ramp",
     "Random",
+    "Quiet",
+    "OnePosition",
     "Drift",
     "Temperature_kev",
     "Temperature_directional",
+    # custom user input
+    "CustomUserInput",
 ]
 
 
@@ -145,5 +517,85 @@ _MODELS = [
 def test_model_roundtrip(name):
     model = _build(name)
     dumped = model.model_dump(mode="json")
+    # the canonical reconstruction path: rebuild from the serialised JSON
     restored = type(model).model_validate(dumped)
+    assert isinstance(restored, type(model)), f"{name} did not reconstruct to its own type: {type(restored).__name__}"
     assert restored.model_dump(mode="json") == dumped, f"{name} does not round-trip through model_dump(mode='json')"
+
+
+def _representative_sim():
+    grid = picmi.Cartesian3DGrid(
+        number_of_cells=[16, 16, 16],
+        lower_bound=[0, 0, 0],
+        upper_bound=[1e-5, 1e-5, 1e-5],
+        lower_boundary_conditions=["periodic", "periodic", "periodic"],
+        upper_boundary_conditions=["periodic", "periodic", "periodic"],
+    )
+    solver = picmi.ElectromagneticSolver(method="Yee", grid=grid)
+    sim = picmi.Simulation(time_step_size=1e-15, max_steps=100, solver=solver)
+
+    profile = picmi.UniformDistribution(density=42, rms_velocity=[1e5, 0, 0], directed_velocity=[1e5, 0, 0])
+    sim.add_species(
+        picmi.Species(name="electron", mass=9.109e-31, charge=-1.602e-19, initial_distribution=profile),
+        picmi.PseudoRandomLayout(n_macroparticles_per_cell=4),
+    )
+    sim.add_species(
+        picmi.Species(name="ion", mass=1.67e-27, charge=1.602e-19, initial_distribution=profile),
+        picmi.PseudoRandomLayout(n_macroparticles_per_cell=2),
+    )
+
+    laser = picmi.GaussianLaser(
+        wavelength=0.8e-6,
+        waist=1e-5,
+        duration=1e-15,
+        focal_position=[0.5e-5, 0.5e-5, 0.5e-5],
+        centroid_position=[0.5e-5, -0.5e-5, 0.5e-5],
+        propagation_direction=[0.0, 1.0, 0.0],
+        polarization_direction=[0.0, 0.0, 1.0],
+        E0=1e10,
+        phi0=0.0,
+        picongpu_huygens_surface_positions=[[1, -1], [1, -1], [1, -1]],
+    )
+    sim.add_laser(laser, None)
+
+    from picongpu.picmi.diagnostics import Checkpoint, PhaseSpace, TimeStepSpec
+
+    sim.add_diagnostic(
+        PhaseSpace(
+            species=sim.species[0],
+            period=TimeStepSpec[::10]("steps"),
+            spatial_coordinate="x",
+            momentum_coordinate="px",
+            min_momentum=-1,
+            max_momentum=1,
+        )
+    )
+    sim.add_diagnostic(Checkpoint(period=TimeStepSpec[::50]("steps")))
+    return sim
+
+
+def test_simulation_roundtrips_from_rendering_context():
+    # the rendering context stored during generate() is the serialised form of
+    # the Simulation; it must be validatable again and re-serialise identically
+    sim = _representative_sim()
+    with tempfile.TemporaryDirectory() as tmp:
+        setup = Path(tmp) / "setup"
+        sim.write_input_file(setup)
+        context = json.loads((setup / "metadata" / "pypicongpu_rendering_context.json").read_text())
+
+    restored = Simulation.model_validate(context)
+    assert restored.model_dump(mode="json") == context, "Simulation does not round-trip through the rendering context"
+
+
+def test_runner_roundtrips_from_runner_metadata():
+    # the runner metadata stored during generate() must be validatable again,
+    # yielding a Runner whose simulation is a proper pypicongpu Simulation
+    sim = _representative_sim()
+    with tempfile.TemporaryDirectory() as tmp:
+        setup = Path(tmp) / "setup"
+        sim.write_input_file(setup)
+        runner_json = json.loads((setup / "metadata" / "pypicongpu_runner.json").read_text())
+
+    restored = Runner.model_validate(runner_json)
+    assert isinstance(restored, Runner)
+    assert isinstance(restored.sim, Simulation)

--- a/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
@@ -682,6 +682,20 @@ def test_collision_functor_malformed_dict_raises_value_error():
         Collision(species_pairs=[(_ELECTRON, _ELECTRON)], functor={"type_constlog": True, "data": {}})
 
 
+def test_radiation_observer_user_index_symbol_not_conflated():
+    # a user direction that uses its own symbol named "index" as a constant
+    # must not be conflated with the observer index: the canonical
+    # serialisation placeholder is mangled, so the user constant survives
+    # the round-trip as a free symbol (n1)
+    tilt = Symbol("index")
+    model = RadiationObserverConfiguration(index_to_direction=lambda i: (tilt + i, 1, 0), N_observer=4)
+    dumped = model.model_dump(mode="json")
+    restored = RadiationObserverConfiguration.model_validate(dumped)
+    assert restored.model_dump(mode="json") == dumped
+    x, y, z = restored.index_to_direction(0)
+    assert x.free_symbols == {tilt}, f"user constant lost in round-trip: {x}"
+
+
 def test_radiation_observer_nonunit_direction_roundtrips():
     # a direction whose magnitude is not symbolically 1 goes through the
     # validator's normalising branch; the reconstructed mapping must still be

--- a/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_roundtrip.py
@@ -206,6 +206,9 @@ def _build(name: str):
         return LogFrequencies(omega_min=1e14, omega_max=1e17)
     if name == "RadiationObserverConfiguration":
         return RadiationObserverConfiguration(index_to_direction=lambda _: [1, 0, 0], N_observer=1)
+    if name == "RadiationObserverConfiguration_nonunit":
+        # a non-unit direction exercises the validator's normalising branch
+        return RadiationObserverConfiguration(index_to_direction=lambda i: (i, 1, 0), N_observer=1)
     if name == "RadiationConfiguration":
         return RadiationConfiguration(frequencies=LogFrequencies(omega_min=1e14, omega_max=1e17))
     if name == "RadiationPluginConfig":
@@ -443,6 +446,7 @@ _MODELS = [
     "LinearFrequencies",
     "LogFrequencies",
     "RadiationObserverConfiguration",
+    "RadiationObserverConfiguration_nonunit",
     "RadiationConfiguration",
     "RadiationPluginConfig",
     "RadiationPlugin",
@@ -676,3 +680,18 @@ def test_collision_functor_malformed_dict_raises_value_error():
     # must fail with a validation-style error, not a raw KeyError
     with pytest.raises(ValueError, match="data.coulomb_log"):
         Collision(species_pairs=[(_ELECTRON, _ELECTRON)], functor={"type_constlog": True, "data": {}})
+
+
+def test_radiation_observer_nonunit_direction_roundtrips():
+    # a direction whose magnitude is not symbolically 1 goes through the
+    # validator's normalising branch; the reconstructed mapping must still be
+    # unit-length and point along the original direction
+    model = RadiationObserverConfiguration(index_to_direction=lambda i: (i, 1, 0), N_observer=8)
+    dumped = model.model_dump(mode="json")
+    restored = RadiationObserverConfiguration.model_validate(dumped)
+    assert restored.model_dump(mode="json") == dumped
+    for k in (3, 7):
+        x, y, z = restored.index_to_direction(k)
+        assert x**2 + y**2 + z**2 == 1
+        assert x / y == k
+        assert z == 0

--- a/lib/python/test/picongpu/quick/pypicongpu/test_setchargestate.py
+++ b/lib/python/test/picongpu/quick/pypicongpu/test_setchargestate.py
@@ -22,7 +22,7 @@ from picongpu.pypicongpu.species.util.element import Element
 def _element_species(symbol):
     return Species(
         name="ion",
-        constants=[ElementProperties(element=Element(symbol)), Mass(mass_si=1.0), Charge(charge_si=1.0)],
+        constants=[ElementProperties(element=Element(openpmd_name=symbol)), Mass(mass_si=1.0), Charge(charge_si=1.0)],
         attributes=[Position(), Momentum(), Weighting()],
     )
 


### PR DESCRIPTION
## What

Makes the `pypicongpu` pydantic models round-trip safe:
`type(inst).model_validate(inst.model_dump(mode="json"))` must hold, and
re-serialising the reconstructed instance must yield the identical dump. The
practical goal is that a valid `Runner`/`Simulation` can be reconstructed
from the `metadata/*.json` artifacts and re-generate the setup byte-identically.

## Rework (2026-08-31)

- **C1 (critical) fixed**: declared `return_type` on the collision
  serializers so collision setups can actually be generated (previously
  rejected by the render-context schema check), plus an e2e collision test.
- M1/n2 (restate the render-regression battery + follow-up guarantee),
  m1 (assert the Runner re-serialisation contract), m2 (malformed collision
  functor -> `ValidationError`), m3 (repair the radiation direction
  normaliser + non-unit corpus entry), m4, n1 integrated.
- One pre-existing `SimpleDensity` species-order flake fixed along the way.

See `TASK-07-RESPONSE.md`.

## Verification

`pytest quick/` green (577), `pre-commit run --all-files` green at the
branch tip.

---
**Internal review PR** (fork `chillenzer/picongpu`). QA cycle completed on-branch: implementation -> independent review (`TASK-07-REVIEW.md`) -> rework (`TASK-07-RESPONSE.md`), all committed at the branch root alongside the camera-ready `TASK-07-PR-PROPOSAL.md`.

**Stacked PR**: the base is the reworked `task-06` branch, so the diff shows only this task's work. Base of the stacked `task-13` branch. Base will be re-pointed to the upstream development branch once approved.