### PR TITLE
PICMI: partial workflow execution (stable stage interface, draft)

### DIFF
--- a/TASK-09-FINDINGS.md
+++ b/TASK-09-FINDINGS.md
@@ -206,7 +206,11 @@ Rules:
   invalidated and re-run. This is how an edit of `input.yaml` after a
   completed run is detected (without it, the run would silently skip every
   stage and reuse stale artifacts).
-- Unreadable/foreign state files are logged and treated as empty.
+- Unreadable/foreign state files are logged and treated as empty. A state
+  file whose `version` is not 1 (the only version this runner writes and
+  reads) is likewise logged and ignored: it is treated as empty, so the next
+  run re-records it (the check makes the `version` field a migration hook for
+  future format changes instead of a dead field).
 - The file is safe to delete (fresh start); `Runner.reset_workflow_state()`
   does it programmatically.
 
@@ -384,7 +388,8 @@ Results (venv `task-09`):
 ## 15. Risks / known limitations
 
 - The stage vocabulary is a **new public commitment**; renaming a stage
-  later breaks the state file (mitigation: state `version` field + the
+  later breaks the state file (mitigation: the state `version` field is
+  checked on load -- unknown versions are ignored, cf. section 6 -- plus the
   "membership may grow, meaning is stable" contract documented in the
   `Stage` docstring).
 - Per-step outdirs named `step-N`: if a stage's steps are renumbered, stale

--- a/TASK-09-FINDINGS.md
+++ b/TASK-09-FINDINGS.md
@@ -335,13 +335,22 @@ installed into the generated setup dir:
    `invalidated` (stale, outside the range).
 7. `test_flags_after_generation_are_rejected` — flags after generation raise
    a clear `ValueError`; the state is left intact.
-8. **Stability test** `test_stability_future_workflow` — a fake "future"
-   workflow where the `submit` stage gains an extra `upload` step chained
-   into `submit` via `StepOutputRef`: the public API (stage names, ranges,
+8. **Stability test** `test_stability_future_workflow` — a "future"
+   workflow simulated as a mutated scratch `workflow.cwl` (a step id renamed,
+   an extra `upload` step inserted ahead of `submit` inside the submit stage)
+   with a correspondingly updated plan: the public API (stage names, ranges,
    state file) works unchanged; the in-stage wiring is verified (the upload
    output reaches the final `tbg`); the state file contains no step names.
    **Result: passed** — the adapter absorbs a step inserted inside an
    existing stage without any API change.
+9. **Plan/template sync** `test_default_plan_matches_workflow_template` —
+   loads the real `templates/workflow/workflow.cwl` and asserts that every
+   plan step covers exactly one workflow step (same file), with the same
+   input names and sources (workflow inputs, stage artifacts, in-stage step
+   outputs), and that every workflow step output is recorded by the plan.
+   The per-step path never reads `workflow.cwl`, so this turns "keep the
+   adapter in sync with the templates" into a CI-enforced invariant (drift
+   would otherwise silently diverge full and partial runs).
 
 Results (venv `task-09`):
 

--- a/TASK-09-FINDINGS.md
+++ b/TASK-09-FINDINGS.md
@@ -229,7 +229,7 @@ runs".
 - While a stage runs, the state is updated `running` -> (on success)
   `completed` with artifacts; on failure the stage is marked `failed` and
   the exception propagates (wrapped in `WorkflowStageError` for cwltool
-  failures).
+  load and execution failures).
 - `force=True`: re-run every stage of the range. `force=Stage`/list: re-run
   those stages; **all transitive dependents are invalidated** (marked
   `invalidated` in the state, persisted) and re-run if they are in the

--- a/TASK-09-FINDINGS.md
+++ b/TASK-09-FINDINGS.md
@@ -1,0 +1,384 @@
+# TASK-09 Findings: Partial Workflow Execution in PICMI (draft)
+
+Branch: `task-09-partial-workflow` (base: `task-05-cwl-cache-ref-purge` @ `33d89313f`)
+
+Status: **draft implementation + design note** (exploratory task convention:
+iterate on, not PR-perfect).
+
+## 1. What was delivered
+
+- `pypicongpu/runner.py`: a stable `Stage` vocabulary, a stage->CWL-step
+  adapter (`StagePlan` + `DEFAULT_STAGE_PLAN`), a stage-keyed persisted
+  workflow state (`run_dir/.workflow_state.json`), and `Runner.run_range()`
+  which executes a range of stages.
+- `picmi/simulation.py`: `Simulation.picongpu_run(up_to=..., from_=...,
+  force=...)`; `step()` keeps its (full-run) semantics and now documents why.
+- Exports: `picongpu.picmi.Stage`, `picongpu.pypicongpu.{Stage,
+  DEFAULT_STAGE_PLAN, WorkflowPrerequisiteError, WorkflowStageError}`.
+- Tests: `lib/python/test/picongpu/quick/picmi/test_partial_workflow.py`
+  (8 tests, tiny echo CWL steps).
+- Docs: `docs/source/usage/picmi/partial_workflow.rst` (+ toctree entry,
+  cross-reference in `picmi/intro.rst`).
+- CHANGELOG entry (draft feature note).
+
+## 2. The stable stage vocabulary (primary design point)
+
+**Decision: the public API speaks in coarse-grained *stages* (milestones),
+never in CWL step names.** The number/names of `workflow.cwl` steps may
+change (e.g. remote-execution upload/download steps get added); stages
+absorb that change.
+
+Current stages, in execution (topological) order:
+
+| stage     | meaning                                    | current CWL step(s)            |
+|-----------|--------------------------------------------|--------------------------------|
+| `build`   | compile the executable (pic-build)         | `build_step`                   |
+| `prepare` | prepare the submission (tbg)               | `prepare_submission_step`      |
+| `submit`  | launch the job on the batch system         | `submit_step`                  |
+| `collect` | organize the results into the run directory| `organize_output_step`         |
+
+Dependencies: `submit` needs `build` + `prepare`; `collect` needs `build` +
+`submit`. Today each stage maps 1:1 onto a CWL step; the adapter supports
+N steps per stage (see the stability test, section 12), so a future
+`submit` = [upload-to-cluster, submit, download] is a mapping change only.
+
+Names chosen per the task proposal (`prepare`, `build`, `submit`,
+`collect`). Rationale: they describe *what is achieved* (a milestone), not
+*how* (a tool invocation). `prepare` is intentionally not
+`prepare_submission` — the stage survives tbg being replaced by a different
+submission-preparation mechanism.
+
+## 3. Public API — chosen shape
+
+```python
+sim.picongpu_run()                              # full pipeline (unchanged default)
+sim.picongpu_run(up_to=Stage.build)             # everything up to and incl. build
+sim.picongpu_run(from_=Stage.submit)            # submit + collect; earlier stages
+                                                # must already be completed
+sim.picongpu_run(from_=Stage.submit, up_to=Stage.submit)  # exactly one stage
+sim.picongpu_run(force=True)                    # re-run everything
+sim.picongpu_run(force=Stage.build)             # re-run build + dependents
+```
+
+- `up_to`/`from_` accept `Stage` or the bare string (`"build"`).
+- Default (no args) = full pipeline, backward compatible (section 9).
+
+**Alternatives considered:**
+
+- `run(stages=[...])` (explicit set): more general, but (a) silently accepts
+  sets that are not "downward closed" (e.g. `[submit]` without `build`)
+  forcing an implicit prerequisite policy anyway, (b) is awkward for the two
+  dominant use cases ("build only", "everything up to submit"), (c) is less
+  readable for resume (`stages=[submit, collect]`). Rejected for the draft.
+- Milestone-only `run("submit")` = "everything up to and including submit":
+  covers "build only" and "run up to X", but not "start at X" (resume from
+  a known-good point) and not "exactly one stage" without also re-running
+  prerequisites. `from_`/`up_to` generalize it: `up_to=Stage.submit` *is*
+  the milestone call. Rejected in favour of `up_to`/`from_`.
+- A `Runner.run_stage(...)`-level API: kept available at the runner level
+  (`Runner.run_range`) for tests/advanced use; the PICMI level is the public
+  surface (Python API only, per the requester).
+
+Open question for the requester: confirm the argument names `up_to`/`from_`
+(`from` is a Python keyword, hence the trailing underscore — an alternative
+would be `since=`/`until=`).
+
+## 4. Stage -> step adapter (implementation)
+
+The adapter is a pure-data pydantic model, the single place that knows the
+current `workflow.cwl` layout:
+
+- `StagePlan`: `order` (topological stage order) + `stages` (name -> spec).
+- `StageSpec`: `depends_on` + `steps` (ordered list of step specs).
+- `StageStepSpec`: `step` (CWL step name, for diagnostics), `run` (CWL file
+  relative to the workflow dir), `inputs` (step input -> source), `outputs`
+  (stage artifact name -> step output name).
+- Input sources: a bare string = workflow input (from `input.yaml`);
+  `StageArtifactRef(stage, artifact)` = artifact recorded by a completed
+  stage; `StepOutputRef(step, output)` = output of a preceding step of the
+  same stage (needed so a stage can grow steps over time, e.g. upload ->
+  submit chaining).
+- `Runner.stage_plan` is a (reassignable) pydantic field defaulting to
+  `DEFAULT_STAGE_PLAN`; the tests inject a modified plan to simulate a
+  "future" workflow.
+
+The default plan mirrors the `in:`/`out:` bindings of `workflow.cwl`
+(steps, lines 112-155) exactly, including the task-05 `destination_path`
+input.
+
+## 5. Execution mechanisms — comparison and recommendation
+
+**Option 1 (chosen): per-step cwltool invocations.** Each stage's steps are
+run as standalone `steps/*.cwl` tools through `cwltool.factory.Factory`, in
+dependency order; outputs of earlier stages are re-staged as File/Directory
+inputs from the state file; a cwltool `cachedir` is shared with the full
+run.
+
+- Pros: the CWL steps are already self-contained tools; no CWL generation;
+  input wiring is a small, testable Python dict; the cwltool job cache keeps
+  working per step; failures are localized to one stage.
+- Cons: re-implements the step->step wiring in Python (mitigated: it is
+  declarative data in the plan, verified by the stability test); per-step
+  outdirs must be managed (private `.stage_outputs/<stage>/step-N` dirs).
+
+**Option 2: sub-workflow generation.** Emit narrowed copies of
+`workflow.cwl` (pruned steps, missing inputs replaced by File/Directory
+inputs pointing at on-disk artifacts) and hand them to cwltool.
+
+- Pros: cwltool does the intra-sub-workflow wiring; DAG validated by cwltool.
+- Cons: requires programmatic CWL *serialization* (cwltool/salad has no
+  clean writer; we would hand-generate YAML), which is fragile, hard to
+  keep in sync with the templates, and duplicates the same state-file wiring
+  for the pruned inputs. More code, more failure modes, for no user-visible
+  benefit at this granularity.
+
+**Option 3: cwltool flags only.** Rejected: cwltool cannot select individual
+workflow steps (`--do-work` etc. only control staging/debugging).
+
+**Recommendation: Option 1**, for the reasons above. It also keeps the
+*default* path byte-for-byte identical (section 9), which option 2 could not
+do as cleanly (the default would also become a generated sub-workflow).
+
+**Composition with the cwltool job cache:** kept as an internal
+optimization. The state file skips at stage granularity; within a (re)run,
+cwltool's `cachedir` (`.cwl_cache`, shared between full and per-step runs)
+skips individual jobs with unchanged inputs. Both layers are independent:
+`force` bypasses the state layer, and the job cache still applies to the
+forced re-runs (a no-op when the inputs changed, which is usually the point
+of forcing).
+
+**Composition with task 05:** the per-step `submit` run passes the same
+stable `destination_path` workflow input (the run dir) into `submit.cwl`, so
+`tbg/submit.start`/`link_results.sh` are stable for partial runs exactly as
+for the full run; the `organize_output` sed-based rewrite remains a safety
+net for per-step runs too (a per-step submit also runs inside a
+`.cwl_cache` job dir).
+
+## 6. State file format
+
+`run_dir/.workflow_state.json` (written atomically via tmp+rename):
+
+```json
+{
+  "version": 1,
+  "updated_at": "2026-08-29T02:57:45.619884",
+  "stages": {
+    "build": {
+      "status": "completed",
+      "updated_at": "2026-08-29T02:57:45.608147",
+      "artifacts": {
+        "bin_directory": {"class": "Directory", "location": "/.../run_dir/.stage_outputs/build/step-1/bin"}
+      }
+    },
+    "submit": {
+      "status": "completed",
+      "updated_at": "...",
+      "artifacts": {
+        "tbg_directory": {"class": "Directory", "location": "/.../run_dir/.stage_outputs/submit/step-1/tbg"},
+        "submission_information": {"class": "File", "location": "/.../run_dir/.stage_outputs/submit/step-1/submission_information.txt"},
+        "link_results_script": {"class": "File", "location": "/.../run_dir/.stage_outputs/submit/step-1/link_results.sh"}
+      }
+    }
+  }
+}
+```
+
+Rules:
+
+- **Keyed by stage names only** (never CWL step names); per-step outdirs are
+  numbered (`step-1`, `step-2`, ...) for the same reason, so the on-disk
+  layout also survives step reorganisation.
+- Artifacts are reduced CWL file objects (`class` + `location`, plain
+  absolute paths) so they can be re-staged verbatim as inputs of later
+  steps.
+- Statuses: `running` (crash marker), `completed`, `failed`, `invalidated`
+  (a dependent of a forced stage). Only `completed` counts as done.
+- Unreadable/foreign state files are logged and treated as empty.
+- The file is safe to delete (fresh start); `Runner.reset_workflow_state()`
+  does it programmatically.
+
+**Full-workflow runs are recorded too.** After a legacy single-invocation
+full run, all four stages are marked `completed`; the artifacts are recorded
+at their stable organized locations in the run dir (`input/`, `tbg/`,
+`submission_information.txt`, `link_results.sh`), and `build.bin_directory`
+at `run_dir/input/bin` (organize_output.sh copies the binaries there). This
+makes "resume after a full run" consistent with "resume after partial
+runs".
+
+## 7. Resume and failure semantics
+
+- Re-run with no args: stages recorded `completed` are skipped; the first
+  incomplete stage runs (and everything after it).
+- A stage marked `running`/`failed`/`invalidated` is re-run.
+- While a stage runs, the state is updated `running` -> (on success)
+  `completed` with artifacts; on failure the stage is marked `failed` and
+  the exception propagates (wrapped in `WorkflowStageError` for cwltool
+  failures).
+- `force=True`: re-run every stage of the range. `force=Stage`/list: re-run
+  those stages; **all transitive dependents are invalidated** (marked
+  `invalidated` in the state, persisted) and re-run if they are in the
+  range. Rationale: downstream artifacts are stale once an input stage is
+  redone (new binaries -> old job results).
+- Crash during a run: the interrupted stage stays `running`; the next run
+  re-runs it (and its dependents, which were never completed).
+
+## 8. Missing prerequisites: decision
+
+**Error, not auto-run.** Requesting a stage whose prerequisites are not
+completed (and not in the requested range) raises
+`WorkflowPrerequisiteError` naming the missing stages. Rationale: implicit
+prerequisite execution would silently start long/irreversible work (a full
+recompile, a cluster submission) that the user did not ask for; the error
+message points at the exact call that would satisfy it. (Auto-run is an
+easy policy swap later if desired.)
+
+## 9. Backward compatibility
+
+- `Runner.run()` is **unchanged** (single cwltool invocation of
+  `workflow.cwl`).
+- `picongpu_run()` with no stage args and no recorded state takes exactly
+  the legacy path: `generate()` + `run()`, i.e. byte-for-byte the full
+  workflow as today (a new `.workflow_state.json` is written afterwards,
+  which is additive).
+- Previously, a *second* `picongpu_run()` on the same setup crashed in
+  `generate()`'s "setup directory must not exist" assert; it now resumes
+  (skips completed stages) — strictly less surprising.
+- New: `picongpu_run(flags=...)` after generation raises a clear `ValueError`
+  instead of the same confusing assert (changing workflow flags would
+  invalidate the recorded state; the existing `generate(exist_ok=True)`
+  path is not re-entrant anyway — the renderer refuses to overwrite
+  rendered files, a pre-existing limitation left untouched).
+- `step()` is unchanged in behaviour (full run only) and now documents that
+  time-stepping and workflow stages are orthogonal.
+
+## 10. Interactions with sibling tasks
+
+- **Task 05** (base): built on top; per-step runs reuse `destination_path`
+  and the organize_output rewrite (section 5). Nothing resurrected.
+- **Task 11** (pre-existing bug): `TBGFlags.overwrite_vars` is a `list`
+  while the CWL input `run_overwrite_vars` is `string?`, so
+  `picongpu_run(o=[...])` is rejected by cwltool. This draft does **not**
+  touch that path (the plan passes the `run_overwrite_vars` workflow input
+  through verbatim, same as the full workflow); fixing it is task 11's.
+  Note for task 11: after a fix, the value will flow into the per-step
+  `prepare` run through the same `input.yaml` value, so no extra work there.
+
+## 11. What the draft implements vs defers
+
+Implemented:
+
+- stage vocabulary + adapter, state file, range API, resume, force with
+  dependent invalidation, prerequisite errors, full-run state recording,
+  PICMI exposure, tests (incl. stability), docs, changelog.
+
+Deliberately deferred (open for the next iteration):
+
+- CLI surface (requester: Python API only for now).
+- Artifact-existence validation: the state is authoritative; if the user
+  deleted artifacts manually, a re-run of a *later* stage would re-stage
+  missing files and cwltool would error. A `verify`/`--check` mode could be
+  added.
+- Concurrency: `build` and `prepare` are independent but run sequentially
+  (cwltool's SingleJobExecutor; parallelism could come later without API
+  change).
+- `stages=[...]` set syntax and milestone shorthand (`run("submit")`) —
+  see open questions.
+- Stale-artifact GC of `.stage_outputs/<stage>/step-N` after plan changes.
+- Pre-existing stale hooks `run_step_path`/`gather_results_script_path`
+  (point to non-existent files, unused) — left untouched.
+
+## 12. Tests and results
+
+`lib/python/test/picongpu/quick/picmi/test_partial_workflow.py` (8 tests)
+uses tiny echo CWL steps (same input names/types as the production steps)
+installed into the generated setup dir:
+
+1. `test_full_run_default_and_state` — default run places final artifacts in
+   the run dir like today; state file is stage-keyed, all stages completed,
+   artifacts are `class`+`location` objects; no step names in the file.
+2. `test_second_run_skips_completed` — a second no-arg run does not redo or
+   even rewrite completed stages (state file byte-identical).
+3. `test_range_build_only` — `up_to=Stage.build` completes exactly `build`;
+   artifact lands in `.stage_outputs/build/step-1/bin`.
+4. `test_incremental_stage_scenario` — the task's manual scenario:
+   build-only, then prepare-only, then submit-only
+   (`from_=up_to=submit`), then collect-only (`from_=collect`); state grows
+   stage by stage and final artifacts match a full run (the built-binary
+   marker flows build -> submit -> collect).
+5. `test_missing_prerequisite_is_an_error` — `from_=Stage.submit` on a fresh
+   run raises `WorkflowPrerequisiteError` (naming `build, prepare`), and
+   nothing is executed; `from_` after `up_to` raises `ValueError`.
+6. `test_force_stage_invalidates_dependents` — full run, then
+   `run_range(up_to=Stage.submit, force=Stage.build)` with a changed build
+   input: build re-runs with new content, submit re-runs (invalidated),
+   prepare is skipped (state entry untouched), collect is marked
+   `invalidated` (stale, outside the range).
+7. `test_flags_after_generation_are_rejected` — flags after generation raise
+   a clear `ValueError`; the state is left intact.
+8. **Stability test** `test_stability_future_workflow` — a fake "future"
+   workflow where the `submit` stage gains an extra `upload` step chained
+   into `submit` via `StepOutputRef`: the public API (stage names, ranges,
+   state file) works unchanged; the in-stage wiring is verified (the upload
+   output reaches the final `tbg`); the state file contains no step names.
+   **Result: passed** — the adapter absorbs a step inserted inside an
+   existing stage without any API change.
+
+Results (venv `task-09`):
+
+- `python -m pytest quick/ -q`: **185 passed, 2 xfailed, 1 xpassed**
+  (baseline on the branch: 177 passed, 2 xfailed, 1 xpassed; +8 new tests,
+  no regressions; includes task 05's 3 workflow tests).
+- `pre-commit run --all-files`: **all hooks passed** (after replacing two
+  non-ASCII characters in the inherited `TASK-05-PR-PROPOSAL.md` task
+  artifact, which made the base branch fail the `require-ascii` hook).
+
+## 13. Documentation
+
+- New self-contained page: `docs/source/usage/picmi/partial_workflow.rst`,
+  added to the usage/PICMI toctree (`docs/source/usage/picmi/index.rst`)
+  and cross-referenced from `picmi/intro.rst`.
+- **Post-PR-5731 note:** the `docs/source/python_package/` pages from PR
+  5731 do not exist on this lineage (per the task brief, no
+  `docs/source/python_package/` files were created). Once PR 5731 lands,
+  the content of `usage/picmi/partial_workflow.rst` should be moved or
+  linked into the `python_package` running-simulation page (the PR proposal
+  must carry this note).
+
+## 14. Open questions for the requester
+
+1. **Stage names**: confirm `prepare`, `build`, `submit`, `collect` and the
+   execution order `build -> prepare -> submit -> collect` (ranges are
+   defined on this order; `up_to=Stage.prepare` means "build + prepare").
+2. **Range syntax**: `up_to`/`from_` (chosen) vs `stages=[...]` vs milestone
+   shorthand `run("submit")`. Can any of the alternatives replace or
+   complement the draft's signature? (`from_` vs `since=`/`until=` naming.)
+3. **force semantics**: dependent invalidation (chosen) vs "re-run only the
+   forced stage and leave dependents recorded-complete".
+4. **Missing prerequisites**: error (chosen, safer) vs auto-run of missing
+   prerequisites.
+5. **Final-stage placement**: the last stage's outputs land in the run dir
+   root (like the full workflow); other stages' outputs in
+   `run_dir/.stage_outputs/...`. Acceptable?
+6. **State on flag change**: flags after generation are rejected (chosen;
+   regeneration is not re-entrant yet — pre-existing renderer limitation).
+   Alternative: auto-regenerate + state reset (needs the renderer fix).
+7. Should `Runner` expose a `verify()` that re-checks recorded artifacts
+   on disk (deferred)?
+
+## 15. Risks / known limitations
+
+- The stage vocabulary is a **new public commitment**; renaming a stage
+  later breaks the state file (mitigation: state `version` field + the
+  "membership may grow, meaning is stable" contract documented in the
+  `Stage` docstring).
+- Per-step outdirs named `step-N`: if a stage's steps are renumbered, stale
+  directories linger until the next run of that stage (harmless; they are
+  wiped before use).
+- State authority: manually deleted artifacts are not detected (section 11).
+- The draft records full-workflow artifacts at the *organized* locations;
+  if `organize_output.sh` ever stops copying `bin` into `input/`, the
+  recorded `build.bin_directory` location would need updating (single place:
+  `Runner._record_full_run`).
+- `picongpu_run` now skips `generate()` when the workflow input exists; any
+  code that relied on the old (crashing) double-generate behaviour would
+  notice — none exists in the repo/tests.

--- a/TASK-09-FINDINGS.md
+++ b/TASK-09-FINDINGS.md
@@ -5,6 +5,17 @@ Branch: `task-09-partial-workflow` (base: `task-05-cwl-cache-ref-purge` @ `33d89
 Status: **draft implementation + design note** (exploratory task convention:
 iterate on, not PR-perfect).
 
+> **Rework (2026-09-02), base moved to task-05 @ `971db962a`.** The base
+> branch was reworked to task-05's step-isolation model: the submit step runs
+> in isolation (resolves `TBG_dstPath`/`--chdir` to its own job-cache workdir)
+> and the `organize_output` step strips the `.cwl_cache` references, so the
+> `destination_path` workflow/submit input was **removed**. Consequently every
+> `destination_path` / submit-step pre-staging reference below (e.g. section 4,
+> section 5 "Composition with task 05", the staging-order caveat) describes the
+> prior base state and is superseded: per-stage outputs are now located by the
+> per-stage outdir + recorded artifacts, not by a stable destination input. See
+> `TASK-09-RESPONSE.md` (rework section) and the PR #13 comment.
+
 ## 1. What was delivered
 
 - `pypicongpu/runner.py`: a stable `Stage` vocabulary, a stage->CWL-step

--- a/TASK-09-FINDINGS.md
+++ b/TASK-09-FINDINGS.md
@@ -45,10 +45,10 @@ N steps per stage (see the stability test, section 12), so a future
 Names chosen per the task proposal (`prepare`, `build`, `submit`,
 `collect`). Rationale: they describe *what is achieved* (a milestone), not
 *how* (a tool invocation). `prepare` is intentionally not
-`prepare_submission` — the stage survives tbg being replaced by a different
+`prepare_submission` - the stage survives tbg being replaced by a different
 submission-preparation mechanism.
 
-## 3. Public API — chosen shape
+## 3. Public API - chosen shape
 
 ```python
 sim.picongpu_run()                              # full pipeline (unchanged default)
@@ -80,7 +80,7 @@ sim.picongpu_run(force=Stage.build)             # re-run build + dependents
   surface (Python API only, per the requester).
 
 Open question for the requester: confirm the argument names `up_to`/`from_`
-(`from` is a Python keyword, hence the trailing underscore — an alternative
+(`from` is a Python keyword, hence the trailing underscore - an alternative
 would be `since=`/`until=`).
 
 ## 4. Stage -> step adapter (implementation)
@@ -106,7 +106,7 @@ The default plan mirrors the `in:`/`out:` bindings of `workflow.cwl`
 (steps, lines 112-155) exactly, including the task-05 `destination_path`
 input.
 
-## 5. Execution mechanisms — comparison and recommendation
+## 5. Execution mechanisms - comparison and recommendation
 
 **Option 1 (chosen): per-step cwltool invocations.** Each stage's steps are
 run as standalone `steps/*.cwl` tools through `cwltool.factory.Factory`, in
@@ -157,6 +157,22 @@ stable `destination_path` workflow input (the run dir) into `submit.cwl`, so
 for the full run; the `organize_output` sed-based rewrite remains a safety
 net for per-step runs too (a per-step submit also runs inside a
 `.cwl_cache` job dir).
+
+**Staging-order caveat (default `bash` preset, inherited from task 05).**
+The submitted job runs `$TBG_dstPath/input/bin/picongpu`, i.e.
+`run_dir/input/bin/picongpu`. The submit step pre-stages `input/bin` and
+`input/etc` into the run dir (task-05 fix in the generated `submit.sh`); the
+rest of the input (the full project copy: metadata, `.build`,
+`ro-crate.json`, ...) is only placed there by `organize_output` (collect).
+A partial run that stops after `submit` therefore leaves a *partial*
+`run_dir/input`: the local job can find its binary (verified with the real
+`submit.cwl`, not the test dummies), but it runs against the partial input,
+and the organized artifacts (`tbg/`, `simOutput` link, submission
+information) only exist after `collect`. In the full workflow this ordering
+is a pre-existing race; "submit now, collect later" makes it explicit.
+Staging the complete `input/` ahead of the job launch (e.g. fully inside the
+submit stage) is a possible future improvement; this draft does not change
+the staging order.
 
 ## 6. State file format
 
@@ -262,11 +278,11 @@ easy policy swap later if desired.)
   which is additive).
 - Previously, a *second* `picongpu_run()` on the same setup crashed in
   `generate()`'s "setup directory must not exist" assert; it now resumes
-  (skips completed stages) — strictly less surprising.
+  (skips completed stages) - strictly less surprising.
 - New: `picongpu_run(flags=...)` after generation raises a clear `ValueError`
   instead of the same confusing assert (changing workflow flags would
   invalidate the recorded state; the existing `generate(exist_ok=True)`
-  path is not re-entrant anyway — the renderer refuses to overwrite
+  path is not re-entrant anyway - the renderer refuses to overwrite
   rendered files, a pre-existing limitation left untouched).
 - `step()` is unchanged in behaviour (full run only) and now documents that
   time-stepping and workflow stages are orthogonal.
@@ -301,49 +317,49 @@ Deliberately deferred (open for the next iteration):
 - Concurrency: `build` and `prepare` are independent but run sequentially
   (cwltool's SingleJobExecutor; parallelism could come later without API
   change).
-- `stages=[...]` set syntax and milestone shorthand (`run("submit")`) —
+- `stages=[...]` set syntax and milestone shorthand (`run("submit")`) -
   see open questions.
 - Stale-artifact GC of `.stage_outputs/<stage>/step-N` after plan changes.
 - Pre-existing stale hooks `run_step_path`/`gather_results_script_path`
-  (point to non-existent files, unused) — left untouched.
+  (point to non-existent files, unused) - left untouched.
 
 ## 12. Tests and results
 
-`lib/python/test/picongpu/quick/picmi/test_partial_workflow.py` (8 tests)
+`lib/python/test/picongpu/quick/picmi/test_partial_workflow.py` (12 tests)
 uses tiny echo CWL steps (same input names/types as the production steps)
 installed into the generated setup dir:
 
-1. `test_full_run_default_and_state` — default run places final artifacts in
+1. `test_full_run_default_and_state` - default run places final artifacts in
    the run dir like today; state file is stage-keyed, all stages completed,
    artifacts are `class`+`location` objects; no step names in the file.
-2. `test_second_run_skips_completed` — a second no-arg run does not redo or
+2. `test_second_run_skips_completed` - a second no-arg run does not redo or
    even rewrite completed stages (state file byte-identical).
-3. `test_range_build_only` — `up_to=Stage.build` completes exactly `build`;
+3. `test_range_build_only` - `up_to=Stage.build` completes exactly `build`;
    artifact lands in `.stage_outputs/build/step-1/bin`.
-4. `test_incremental_stage_scenario` — the task's manual scenario:
+4. `test_incremental_stage_scenario` - the task's manual scenario:
    build-only, then prepare-only, then submit-only
    (`from_=up_to=submit`), then collect-only (`from_=collect`); state grows
    stage by stage and final artifacts match a full run (the built-binary
    marker flows build -> submit -> collect).
-5. `test_missing_prerequisite_is_an_error` — `from_=Stage.submit` on a fresh
+5. `test_missing_prerequisite_is_an_error` - `from_=Stage.submit` on a fresh
    run raises `WorkflowPrerequisiteError` (naming `build, prepare`), and
    nothing is executed; `from_` after `up_to` raises `ValueError`.
-6. `test_force_stage_invalidates_dependents` — full run, then
+6. `test_force_stage_invalidates_dependents` - full run, then
    `run_range(up_to=Stage.submit, force=Stage.build)` with a changed build
    input: build re-runs with new content, submit re-runs (invalidated),
    prepare is skipped (state entry untouched), collect is marked
    `invalidated` (stale, outside the range).
-7. `test_flags_after_generation_are_rejected` — flags after generation raise
+7. `test_flags_after_generation_are_rejected` - flags after generation raise
    a clear `ValueError`; the state is left intact.
-8. **Stability test** `test_stability_future_workflow` — a "future"
+8. **Stability test** `test_stability_future_workflow` - a "future"
    workflow simulated as a mutated scratch `workflow.cwl` (a step id renamed,
    an extra `upload` step inserted ahead of `submit` inside the submit stage)
    with a correspondingly updated plan: the public API (stage names, ranges,
    state file) works unchanged; the in-stage wiring is verified (the upload
    output reaches the final `tbg`); the state file contains no step names.
-   **Result: passed** — the adapter absorbs a step inserted inside an
+   **Result: passed** - the adapter absorbs a step inserted inside an
    existing stage without any API change.
-9. **Plan/template sync** `test_default_plan_matches_workflow_template` —
+9. **Plan/template sync** `test_default_plan_matches_workflow_template` -
    loads the real `templates/workflow/workflow.cwl` and asserts that every
    plan step covers exactly one workflow step (same file), with the same
    input names and sources (workflow inputs, stage artifacts, in-stage step
@@ -351,15 +367,34 @@ installed into the generated setup dir:
    The per-step path never reads `workflow.cwl`, so this turns "keep the
    adapter in sync with the templates" into a CI-enforced invariant (drift
    would otherwise silently diverge full and partial runs).
+10. **Input-change detection** `test_input_change_invalidates_completed_stages` -
+    full run, edit `build_cmake` in `workflow/input.yaml`, re-run with no
+    args: the build stage (changed input) and its dependents (submit,
+    collect) are re-run with the new input visible in the final artifacts,
+    while prepare (unchanged input) is skipped. Without the per-stage
+    `inputs_digest`, this re-run would have been a silent no-op reusing
+    stale artifacts.
+11. **Load-failure error contract** `test_step_file_renamed_raises_workflow_stage_error` -
+    rename the (dummy) `build.cwl` step file so the plan points at a missing
+    file: the cwltool load failure surfaces as `WorkflowStageError`, not a
+    raw cwltool exception.
+12. **State version check** `test_unknown_state_version_is_ignored` - a
+    state file with an unknown `version` is ignored (treated as empty): the
+    stage is re-run and the state is re-recorded with the supported version.
 
-Results (venv `task-09`):
+Results (venv `task-09`, after the rework):
 
-- `python -m pytest quick/ -q`: **185 passed, 2 xfailed, 1 xpassed**
-  (baseline on the branch: 177 passed, 2 xfailed, 1 xpassed; +8 new tests,
-  no regressions; includes task 05's 3 workflow tests).
-- `pre-commit run --all-files`: **all hooks passed** (after replacing two
-  non-ASCII characters in the inherited `TASK-05-PR-PROPOSAL.md` task
-  artifact, which made the base branch fail the `require-ascii` hook).
+- `python -m pytest quick/ -q`: **190 passed, 2 xfailed, 1 xpassed**
+  (3499 subtests; baseline on the branch in this environment: 186 passed,
+  2 xfailed, 1 xpassed; +4 new tests, no regressions; includes task 05's
+  workflow tests).
+- `pre-commit run --all-files`: **all hooks passed** (verified by running
+  it). Note: at the time of the original review, this file's em dashes
+  failed `require-ascii`; the file has now been ASCII-normalized (em dash to
+  hyphen, the same treatment applied to the inherited
+  `TASK-05-PR-PROPOSAL.md`), so the claim holds under the hook config of
+  either time. (The review commit additionally added a `^TASK-.*\.md$`
+  exclusion to the hook; that exclusion was not part of the reviewed code.)
 
 ## 13. Documentation
 
@@ -389,7 +424,7 @@ Results (venv `task-09`):
    root (like the full workflow); other stages' outputs in
    `run_dir/.stage_outputs/...`. Acceptable?
 6. **State on flag change**: flags after generation are rejected (chosen;
-   regeneration is not re-entrant yet — pre-existing renderer limitation).
+   regeneration is not re-entrant yet - pre-existing renderer limitation).
    Alternative: auto-regenerate + state reset (needs the renderer fix).
 7. Should `Runner` expose a `verify()` that re-checks recorded artifacts
    on disk (deferred)?
@@ -411,4 +446,4 @@ Results (venv `task-09`):
   `Runner._record_full_run`).
 - `picongpu_run` now skips `generate()` when the workflow input exists; any
   code that relied on the old (crashing) double-generate behaviour would
-  notice — none exists in the repo/tests.
+  notice - none exists in the repo/tests.

--- a/TASK-09-FINDINGS.md
+++ b/TASK-09-FINDINGS.md
@@ -139,13 +139,17 @@ workflow steps (`--do-work` etc. only control staging/debugging).
 *default* path byte-for-byte identical (section 9), which option 2 could not
 do as cleanly (the default would also become a generated sub-workflow).
 
-**Composition with the cwltool job cache:** kept as an internal
-optimization. The state file skips at stage granularity; within a (re)run,
-cwltool's `cachedir` (`.cwl_cache`, shared between full and per-step runs)
-skips individual jobs with unchanged inputs. Both layers are independent:
-`force` bypasses the state layer, and the job cache still applies to the
-forced re-runs (a no-op when the inputs changed, which is usually the point
-of forcing).
+**Composition with the cwltool job cache:** the legacy single-invocation
+full run (`Runner.run()`) keeps the shared `.cwl_cache` as before (job-level
+resume safety net). Per-step invocations deliberately do not use the job
+cache (`cachedir=None`): the stage state file is the skip mechanism of the
+per-step path, and invoked steps always execute freshly. This is required
+for correctness, not just an optimization: cwltool's cache key does not
+cover the *contents* of `Directory` inputs, so a re-run stage that
+regenerates an artifact directory in place (same `.stage_outputs` path)
+would otherwise let its dependents hit a stale cache entry (verified before
+the fix: `force=Stage.build` after changing `build_cmake` produced the new
+binary, but the submit step's *cached* tbg still contained the old one).
 
 **Composition with task 05:** the per-step `submit` run passes the same
 stable `destination_path` workflow input (the run dir) into `submit.cwl`, so
@@ -166,6 +170,7 @@ net for per-step runs too (a per-step submit also runs inside a
     "build": {
       "status": "completed",
       "updated_at": "2026-08-29T02:57:45.608147",
+      "inputs_digest": "9f86d081884c7d65...",
       "artifacts": {
         "bin_directory": {"class": "Directory", "location": "/.../run_dir/.stage_outputs/build/step-1/bin"}
       }
@@ -173,6 +178,7 @@ net for per-step runs too (a per-step submit also runs inside a
     "submit": {
       "status": "completed",
       "updated_at": "...",
+      "inputs_digest": "3a7bd1e02c9f48ab...",
       "artifacts": {
         "tbg_directory": {"class": "Directory", "location": "/.../run_dir/.stage_outputs/submit/step-1/tbg"},
         "submission_information": {"class": "File", "location": "/.../run_dir/.stage_outputs/submit/step-1/submission_information.txt"},
@@ -193,6 +199,13 @@ Rules:
   steps.
 - Statuses: `running` (crash marker), `completed`, `failed`, `invalidated`
   (a dependent of a forced stage). Only `completed` counts as done.
+- `inputs_digest`: sha256 of the workflow inputs (from `workflow/input.yaml`)
+  the stage consumed, recorded when it runs. On a re-run, a completed stage
+  whose digest no longer matches (or has none, e.g. a state file from before
+  digest recording) is treated as stale: it and its transitive dependents are
+  invalidated and re-run. This is how an edit of `input.yaml` after a
+  completed run is detected (without it, the run would silently skip every
+  stage and reuse stale artifacts).
 - Unreadable/foreign state files are logged and treated as empty.
 - The file is safe to delete (fresh start); `Runner.reset_workflow_state()`
   does it programmatically.
@@ -207,8 +220,11 @@ runs".
 
 ## 7. Resume and failure semantics
 
-- Re-run with no args: stages recorded `completed` are skipped; the first
+- Re-run with no args: stages recorded `completed` are skipped (only if the
+  workflow inputs they consumed are unchanged, see section 6); the first
   incomplete stage runs (and everything after it).
+- Changed workflow inputs invalidate the affected stages and their
+  dependents (logged), so an edited `input.yaml` is never silently ignored.
 - A stage marked `running`/`failed`/`invalidated` is re-run.
 - While a stage runs, the state is updated `running` -> (on success)
   `completed` with artifacts; on failure the stage is marked `failed` and

--- a/TASK-09-RESPONSE.md
+++ b/TASK-09-RESPONSE.md
@@ -84,3 +84,53 @@ corrected for correctness (noted below).
   tests, no regressions.
 - `pre-commit run --all-files` (worktree root, venv pre-commit) -> exit 0,
   all 21 hooks passed (run after all rework commits; this file is ASCII).
+
+## Rework (2026-09-02): consistency with the reworked base (task-05)
+
+The base branch `task-05-cwl-cache-ref-purge` was reworked (`971db962a`,
+"Reorganize CWL cache fix around step isolation"). The old "stable
+`destination_path`" design was dropped in favor of CWL step isolation: the
+submit step runs in its own per-step job-cache workdir (resolving
+`TBG_dstPath`/`--chdir` to `$(pwd -P)`) and the `organize_output` step strips
+the `.cwl_cache` references from every generated file except `link_results.sh`.
+`destination_path` was removed from `submit.cwl`, `workflow.cwl` and the
+`runner.py` plumbing.
+
+This branch was therefore rebased onto `971db962a`. The rebase was clean:
+task-09's changes are additive (the `Stage`/`StagePlan`/state machinery) in
+regions task-05 did not touch, so `generate_submission_command` /
+`generate_workflow_input` and the CWL templates simply take task-05's
+isolation form. No conflict resolution was needed.
+
+**`destination_path` decision: removed (not kept).** It is a leftover mirroring
+task-05's now-removed stable-destination input, not a distinct partial-execution
+capability. The "resume where a prior stage left off" behavior the feature
+needs is already provided without it:
+- each stage's outputs land in a deterministic outdir (`_stage_outdir`:
+  `run_dir/.stage_outputs/<stage>/step-N`, or `run_dir` for the final stage);
+- those artifacts are recorded in `.workflow_state.json` as reduced CWL objects
+  and re-staged as inputs of later stages via `StageArtifactRef`;
+- the `organize_output` (collect) step makes the final `run_dir` self-contained
+  by stripping the cache references, exactly as in the full run.
+
+So a separate `destination_path` is redundant under the isolation model, and
+keeping it would contradict task-05.
+
+**Interface/test changes (all mechanical, feature preserved):**
+- `DEFAULT_STAGE_PLAN` (submit step): dropped the `destination_path` input so
+  the plan again mirrors `workflow.cwl` exactly (`test_default_plan_matches_workflow_template`).
+- `generate_submission_command` / `generate_workflow_input`: now task-05's
+  isolation form (no stable-destination plumbing); `test_workflow.py` is
+  task-05's, asserting the submit step runs in isolation with no
+  `destination_path`.
+- `test_partial_workflow.py`: `ECHO_SUBMIT_CWL` and `future_stage_plan()`
+  dropped the `destination_path` input.
+- The per-step `submit` still runs inside a `.cwl_cache` job dir, and `collect`
+  strips the references, so partial runs behave like the full run.
+
+**Gates (re-run after the rebase):**
+- `cd lib/python && python -m pytest test/picongpu/quick/ -q` ->
+  **190 passed, 2 xfailed, 1 xpassed** (3499 subtests), exit 0.
+- `pre-commit run --all-files` -> exit 0 (all hooks passed; this file and the
+  `TASK-09-*.md` artifacts are ASCII, since task-05's rework dropped the
+  `^TASK-.*\.md$` require-ascii exclusion and task-09 keeps its artifacts).

--- a/TASK-09-RESPONSE.md
+++ b/TASK-09-RESPONSE.md
@@ -30,15 +30,17 @@ corrected for correctness (noted below).
   behavior unchanged). New test
   `test_input_change_invalidates_completed_stages` proves the new input is
   visible in the final artifacts (not silently skipped).
-- **m1 - accepted, with an environment note** (`470dcfce2`). ASCII-normalized
-  `TASK-09-FINDINGS.md` (all em dashes to hyphens, same treatment as
-  `TASK-05-PR-PROPOSAL.md`) and corrected section 12 (12 tests, final
-  numbers, hook claim phrased as what is actually true). Note: the "pre-commit
-  is failing" claim was true at the reviewed code tip `7e6e67bd8` (no
-  `TASK-*.md` exclusion existed there), but the review commit `fd539988e`
-  itself added the `^TASK-.*\.md$` exclusion, so at the review tip
-  `pre-commit run --all-files` already exits 0. The normalization was applied
-  anyway, so the claim holds under either hook config.
+- **m1 - accepted, with an environment note** (`470dcfce2`, plus
+  `2f5da778b`). ASCII-normalized `TASK-09-FINDINGS.md` (all em dashes to
+  hyphens, same treatment as `TASK-05-PR-PROPOSAL.md`) and corrected section
+  12 (12 tests, final numbers, hook claim phrased as what is actually true);
+  `2f5da778b` also normalizes one pre-existing em dash in
+  `partial_workflow.rst` so every file this branch touched is ASCII. Note:
+  the "pre-commit is failing" claim was true at the reviewed code tip
+  `7e6e67bd8` (no `TASK-*.md` exclusion existed there), but the review commit
+  `fd539988e` itself added the `^TASK-.*\.md$` exclusion, so at the review
+  tip `pre-commit run --all-files` already exits 0. The normalization was
+  applied anyway, so the claim holds under either hook config.
 - **m2 - accepted** (`304da40b6`). New
   `test_default_plan_matches_workflow_template` loads the real
   `templates/workflow/workflow.cwl` (YAML) and asserts all invariants from the

--- a/TASK-09-RESPONSE.md
+++ b/TASK-09-RESPONSE.md
@@ -1,0 +1,84 @@
+# Task 09 - Rework Response
+
+All findings were independently re-verified before integration (reviewer's
+probes re-run, plus extra probes against the real step templates where the
+probes used dummies). No findings rejected; three suggested fixes were
+corrected for correctness (noted below).
+
+## Findings
+
+- **M1 - accepted** (`9a63ad1c9`). Rewrote the resume section of
+  `partial_workflow.rst` with a range-based failure/resume example and an
+  explicit statement that a failed *default* run leaves no stage state and
+  resumes only at job granularity via the cwltool cache (byte-identical
+  inputs). Softened the CHANGELOG sentence and the `picongpu_run` docstring
+  (the same claim was also there). Reviewer's probe I re-run: no state file
+  after a failed default run, confirmed.
+- **M2 - accepted, suggested fix corrected** (`3488ef7c2`). Per-stage
+  `inputs_digest` (sha256 of the consumed workflow inputs) recorded in
+  `_run_stage`/`_record_full_run`, re-checked in `run_range`. Correction 1:
+  the sketch downgrades only stages whose *own* digest changed - insufficient,
+  because downstream stages whose inputs are artifacts of the stale stage
+  would still be skipped; stale stages are invalidated together with their
+  transitive dependents (same mechanism as `force`). Correction 2 (bug found
+  while testing): per-step re-runs consulted the shared cwltool job cache,
+  whose key does not cover `Directory` contents, so an invalidated dependent
+  received a *stale* cached output (verified: even pre-existing
+  `force=Stage.build` produced the new binary but a cached submit tbg still
+  embedding the old one). Per-step invocations now run with `cachedir=None`;
+  the legacy single-invocation path keeps the shared `.cwl_cache` (task-05
+  behavior unchanged). New test
+  `test_input_change_invalidates_completed_stages` proves the new input is
+  visible in the final artifacts (not silently skipped).
+- **m1 - accepted, with an environment note** (`470dcfce2`). ASCII-normalized
+  `TASK-09-FINDINGS.md` (all em dashes to hyphens, same treatment as
+  `TASK-05-PR-PROPOSAL.md`) and corrected section 12 (12 tests, final
+  numbers, hook claim phrased as what is actually true). Note: the "pre-commit
+  is failing" claim was true at the reviewed code tip `7e6e67bd8` (no
+  `TASK-*.md` exclusion existed there), but the review commit `fd539988e`
+  itself added the `^TASK-.*\.md$` exclusion, so at the review tip
+  `pre-commit run --all-files` already exits 0. The normalization was applied
+  anyway, so the claim holds under either hook config.
+- **m2 - accepted** (`304da40b6`). New
+  `test_default_plan_matches_workflow_template` loads the real
+  `templates/workflow/workflow.cwl` (YAML) and asserts all invariants from the
+  review: step files, input names/sources (workflow inputs, stage artifacts,
+  in-stage step outputs), and output coverage, plus the reverse direction.
+  Verified to fail against a drifted template (renamed workflow input).
+  `test_stability_future_workflow` re-framed to mutate a scratch
+  `workflow.cwl` (renamed step id + inserted step) with a correspondingly
+  updated plan, exercising plan/workflow drift instead of plan self-consistency.
+- **m3 - accepted** (`15fe49513`). The `WorkflowFactory(...).make(...)(**inputs)`
+  call now wraps any load/validation exception (e.g. a renamed step file) in
+  `WorkflowStageError`; the specific `WorkflowStatus` message is kept. New test
+  `test_step_file_renamed_raises_workflow_stage_error`.
+- **n1 - accepted, check implemented** (`6c29b4489`).
+  `_load_workflow_state` now ignores state files with `version != 1` (logged
+  warning, treated as empty, re-recorded on the next run) - chosen over
+  dropping the field so the version is a real migration hook. New test
+  `test_unknown_state_version_is_ignored`.
+- **n2 - accepted** (`38b430a45`). The legacy full-run path now returns the
+  recorded artifacts of the final stage instead of the raw workflow outputs
+  dict, matching the documented "artifacts of the last executed stage, or
+  None" contract; `picongpu_run` discards the return value (unchanged).
+  Pinned in tests: the default run returns the collect artifacts, an up-to-date
+  re-run returns `None`.
+- **FYI (bash preset staging) - accepted, claim corrected** (`26b1540d9`,
+  FINDINGS note in `470dcfce2`). Caveat added to `partial_workflow.rst`
+  (Semantics) and FINDINGS section 5. Correction: the review's "deterministically
+  cannot find its binary" is an artifact of the dummy echo steps in its probe;
+  with the real `submit.cwl` the task-05 pre-staging places `input/bin` and
+  `input/etc` into the run dir even for a per-step submit (verified by probe),
+  so the local job finds its binary but runs against a *partial* input
+  directory (metadata, `.build`, `ro-crate.json` appear only after `collect`).
+  Staging order itself unchanged, per the rework scope.
+
+## Gates
+
+- `cd lib/python/test/picongpu && python -m pytest quick/ -q` ->
+  **190 passed, 2 xfailed, 1 xpassed** (3499 subtests), exit 0. Baseline at
+  the review tip in this environment: 186 passed, 2 xfailed, 1 xpassed
+  (the review reported 185; one test differs between environments). +4 new
+  tests, no regressions.
+- `pre-commit run --all-files` (worktree root, venv pre-commit) -> exit 0,
+  all 21 hooks passed (run after all rework commits; this file is ASCII).

--- a/TASK-09-REVIEW.md
+++ b/TASK-09-REVIEW.md
@@ -1,0 +1,323 @@
+# Review — Task 09: Partial Workflow Execution (Stable Stage Interface)
+
+- **Branch:** `task-09-partial-workflow` (tip `7e6e67bd8`, base `task-05-cwl-cache-ref-purge` @ `33d89313f`)
+- **Reviewed:** 2026-08-31 · **Scope:** 7 commits, 11 files, +1572/−19
+- **Verdict:** REQUEST CHANGES
+  (Sound design and a working draft, but the artifact contains two false claims — a failed "pre-commit green" and a doc example that misdescribes the flagship resume behavior — plus a silent-no-op hazard on changed inputs.)
+
+## 1. Summary
+
+The branch adds a `Stage` vocabulary (`build`/`prepare`/`submit`/`collect`), a
+data-driven stage→CWL-step adapter (`StagePlan`/`DEFAULT_STAGE_PLAN`), a
+stage-keyed persisted state file (`run_dir/.workflow_state.json`), and
+`Runner.run_range(up_to/from_/force)` exposed as
+`Simulation.picongpu_run(up_to=..., from_=..., force=...)`. Scope is
+correctly Python-only (no C++/template/CWL changes in the diff). I verified the
+test gate (185 passed = 177 baseline + 8 new), re-implemented the author's
+scenarios in scratch scripts, and attacked the core promise: renaming CWL step
+ids in `workflow.cwl` is transparent to the stage API (the per-step path
+bypasses `workflow.cwl` entirely and the plan references step *files*, not ids),
+and the state/on-disk layout is genuinely step-name-free. The main problems:
+(1) a failed *default* (no-arg) run records no stage state at all, so the
+documented "resume after a failed run" example is false for the most common
+entry point; (2) the state has no link to the inputs that produced the
+artifacts — after any completed run, editing `input.yaml` and calling
+`picongpu_run()` silently does nothing and reuses stale artifacts; (3) the
+"pre-commit green" claim is false (the author's own `TASK-09-FINDINGS.md`
+fails `require-ascii`).
+
+## 2. Findings
+
+### 2.1 Critical
+
+None found.
+
+### 2.2 Major
+
+**M1** — **`docs/source/usage/picmi/partial_workflow.rst:66-82`** (and the
+same wording in `CHANGELOG.md:12`) — the flagship "resume after a failed run"
+story does not hold for the default (no-arg) call, and the doc example asserts
+it does.
+- The example shows `sim.picongpu_run()` failing inside `submit`, then a
+  second `sim.picongpu_run()` where "only 'submit' and 'collect' are re-run".
+  That is false: the legacy full-run path records state **only after
+  success** — `run_range` calls `self._record_full_run(state, outputs)`
+  (runner.py:967-968) only after `self.run()` returns. A failed default run
+  leaves **no state file at all**, so the second call sees an empty state,
+  takes the legacy path again, and re-runs the whole `workflow.cwl`.
+  `build`/`prepare` are skipped only if cwltool's job cache hits — i.e. only
+  when the "fix" did not change any input, which is usually not the case.
+  - *Evidence:* scratch repro (`/tmp/opencode/review-09/probe_i.py`): failing
+    `submit` dummy, `sim.picongpu_run()` → raises `WorkflowStatus`; afterwards
+    `run_dir/.workflow_state.json` **does not exist** (only `.cwl_cache` with
+    6 job entries). Stage-level resume *does* work for range-started runs
+    (verified: `up_to=submit` fails → no-arg resume re-ran only submit+collect,
+    build/prepare untouched), so the feature exists but the documented
+    default-call example is wrong.
+  - *Suggested fix:* (a) Rewrite the doc section: state that stage-level resume
+    applies to runs started with an explicit range (`up_to`/`from_`), while a
+    failed *default* run resumes at job granularity via the cwltool cache only
+    when inputs are byte-identical; show the range-based example instead.
+    (b) Soften the CHANGELOG sentence "so failed or stopped runs can be
+    resumed without redoing the successful stages" to match.
+  - *Alternative:* if stage-level resume after a failed default run is wanted,
+    the default path would need per-step progress during the single cwltool
+    invocation (e.g. always drive stages individually, or poll the job cache)
+    — both change the "default = single invocation" invariant, so for a draft
+    the honest documentation is the right call.
+
+**M2** — **`lib/python/picongpu/pypicongpu/runner.py:998-1002`** (skip loop) +
+`picongpu_run` (simulation.py:527-535) — the persisted state carries no
+fingerprint of the inputs that produced the recorded artifacts, so a run whose
+inputs changed is silently skipped, reusing stale artifacts.
+- After a completed run, `completed` stages are unconditionally skipped
+  (runner.py:999). The state is authoritative about *nothing* regarding
+  inputs. The public API correctly rejects flag changes after generation
+  (simulation.py:530-534), but `workflow/input.yaml` is a plain file the user
+  may edit (the `build_`/`run_` prefix convention exists precisely "in cases
+  when one wants to run the steps individually", runner.py:606-608) — and
+  editing it invalidates the state with zero detection.
+  - *Evidence:* scratch repro (`/tmp/opencode/review-09/probe_a.py`, probe B):
+    full run → edit `build_cmake` in `input.yaml` to `"v2"` →
+    `sim.picongpu_run()` returns `None`, state file byte-identical, and the
+    final `input/bin/picongpu` still contains `built-default` — the user gets
+    no indication that their input change was ignored and the simulation was
+    *not* re-run.
+  - *Suggested fix:* store an input fingerprint per stage (or globally) in the
+    state, e.g. in `StageState` add
+    `inputs_digest: str | None = None` and set it to
+    `hashlib.sha256(json.dumps(consumed_workflow_inputs, sort_keys=True).encode()).hexdigest()`
+    in `_run_stage` / `_record_full_run` (the consumed inputs are exactly the
+    string-sourced entries of the step specs, resolvable in
+    `_resolve_step_inputs`). In `run_range`, after loading state, recompute the
+    digest from `workflow_input_path` and downgrade `completed` →
+    `invalidated` (with a logged message) for stages whose digest no longer
+    matches. Coarse variant: one digest of the whole `input.yaml`; any change
+    invalidates all stages — simpler, still eliminates the silent no-op.
+  - *Alternative:* for the no-arg all-completed case, fall back to the legacy
+    `self.run()` path and let the cwltool cache decide what to skip —
+    restores "call again → it re-runs (cheaply) when inputs changed" without
+    fingerprinting, but loses stage granularity and changes the observed
+    behavior of an up-to-date re-run from no-op to cache-checked re-run.
+
+### 2.3 Minor
+
+**m1** — **`TASK-09-FINDINGS.md` (19 occurrences, e.g. :48, :363, :384)** — the
+claim "`pre-commit run --all-files`: all hooks passed" (§12) is false; the
+task's "Verification: Pre-commit green" is not met.
+- *Evidence:* `/tmp/opencode/venvs/task-09/bin/pre-commit run --files <all 11
+  changed files>` → `require-ascii` **Failed, exit 1** on
+  `TASK-09-FINDINGS.md` (19 em-dashes `—`). All other hooks pass (ruff,
+  ruff-format, trailing-whitespace, end-of-file-fixer, …). Ironic detail: the
+  branch *did* fix the inherited `TASK-05-PR-PROPOSAL.md` em-dashes to make the
+  hook pass, but left the new artifact doc non-ASCII — so `--all-files`
+  fails on the file this very branch added.
+  - *Suggested fix:* ASCII-ify `TASK-09-FINDINGS.md` (same `—`→`-`
+    normalization as in `TASK-05-PR-PROPOSAL.md`) and actually run
+    `pre-commit run --all-files` before claiming it in §12.
+
+**m2** — **`lib/python/picongpu/pypicongpu/runner.py:261-351`**
+(`DEFAULT_STAGE_PLAN`) + `lib/python/test/picongpu/quick/picmi/test_partial_workflow.py:442-466` —
+nothing verifies the plan against the real `workflow.cwl`, and the "stability
+test" is tautological.
+- The adapter is by design "the single place that knows the current CWL
+  steps", but it is plain data with no sync check. If `workflow.cwl` drifts
+  (a step file renamed, an input renamed, a step added), full runs and
+  partial runs silently diverge: the full run follows `workflow.cwl`, the
+  per-step path follows the plan.
+  - *Evidence:* scratch probes (`/tmp/opencode/review-09/probe_def.py`):
+    (a) current plan *is* in sync (all plan step files exist in the template;
+    all plan workflow-input names are defined in `workflow.cwl`; step-output
+    refs map to the right producing stages — verified by parsing
+    `templates/workflow/workflow.cwl`), so no live bug; (b) inserting a 5th
+    `validate_step` into a scratch `workflow.cwl` runs it in the full run but
+    the per-step resume never runs it again — silent divergence; (c) the
+    shipped stability test only reassigns `runner.stage_plan` with a synthetic
+    plan, i.e. it proves "the code accepts a different plan", not that the
+    default plan survives a workflow change. (Renaming CWL step *ids* is in
+    fact transparent — verified in scratch — because per-step execution
+    bypasses `workflow.cwl`.)
+  - *Suggested fix:* add a test that loads the *real*
+    `templates/workflow/workflow.cwl` (yaml) and asserts, for every plan step
+    spec: its `run` file exists in the template; every string input source is
+    a workflow input; every `StageArtifactRef` points at an artifact recorded
+    by the stage that implements the referenced workflow step; every step
+    output in the workflow's `out:` list is covered. Re-frame
+    `test_stability_future_workflow` to mutate a scratch `workflow.cwl`
+    (rename/insert a step) plus a correspondingly updated plan, so the test
+    exercises the actual failure mode (plan/workflow drift) instead of
+    self-consistency.
+
+**m3** — **`lib/python/picongpu/pypicongpu/runner.py:839-855`** (`_run_cwl_step`) —
+only `WorkflowStatus` is caught, so cwltool *load/validation* failures surface
+as raw `cwltool` exceptions instead of the documented `WorkflowStageError`.
+- *Evidence:* scratch probe: rename `steps/build.cwl` → `compile.cwl` in a
+  scratch setup (plan unchanged) → `run_range(up_to=Stage.build)` raises
+  `cwltool...ValidationException`, not `WorkflowStageError`; the failure is
+  loud (good), but the error contract stated in the docstrings ("wrapped in
+  `WorkflowStageError` for cwltool failures") does not hold for the most
+  likely drift scenario.
+  - *Suggested fix:* wrap the whole
+    `WorkflowFactory(...).make(str(step_path))(**inputs)` expression in
+    `except Exception as error: raise WorkflowStageError(...) from error`
+    (keep the specific `WorkflowStatus` message), so stage execution has one
+    error type.
+
+### 2.4 Nits
+
+**n1** — **`lib/python/picongpu/pypicongpu/runner.py:386`** — the state
+`version` field is never consulted (probe: a state file with `version: 99`
+loads without comment). It is a placeholder for migration logic that does not
+exist; either implement a check (reject/`reset` on unknown version) or drop
+the field until it means something.
+
+**n2** — **`lib/python/picongpu/pypicongpu/runner.py:965-969` vs `:997-1003`** —
+`run_range`'s return value is shape-inconsistent: the legacy path returns the
+full-workflow outputs dict, the per-step path returns the last executed
+stage's artifacts or `None`. Inconsequential through `picongpu_run` (which
+discards it), but the Runner-level contract ("Returns the artifacts of the
+last executed stage, or None") is violated by the legacy branch.
+
+## 3. Requirement traceability
+
+| # | Requirement (from task file) | Status | Where / note |
+|---|---|---|---|
+| 1 | PICMI-level interface to execute subsets of the CWL workflow | met | `picongpu_run(up_to/from_/force)` (simulation.py:506-535) → `Runner.run_range` (runner.py:930-1003) |
+| 2 | Resume after a failed/partial run without redoing successful steps | partial | Works for range-started runs (verified); a failed *default* run records no state, and the doc example claiming otherwise is false → M1 |
+| 3 | Run `build` without `submit` / `submit` after out-of-band build / `organize_output` after manual intervention | met (API level) | `up_to=Stage.build`, `from_=Stage.submit`, `force=Stage.collect`; real-`bash`-preset staging caveat → FYI |
+| 4 | Implemented in the Python package, with tests, and documented | met | 8 tests (`test_partial_workflow.py`), `partial_workflow.rst` + toctree + cross-ref |
+| 5 | Public interface must NOT address CWL steps by name (stable across step number/name changes) | met | State keyed by stage, outdirs `step-N` numbered; step-id renames verified transparent (scratch probe F1); plan is the single internal change point, but unvalidated → m2 |
+| 6 | Python API only (no CLI) | met | diff touches only `lib/python` + docs/CHANGELOG/task md; no CLI, no C++/templates |
+| 7 | Explore solution space → best option → draft implementation | met | FINDINGS §5 compares per-step vs sub-workflow vs flags-only, recommends per-step with trade-offs |
+| 8 | Stage→step adapter as the single place knowing the current steps | met (partial) | `StagePlan`/`DEFAULT_STAGE_PLAN` (runner.py:233-351); currently in sync with the template (verified) but no sync test → m2 |
+| 9 | State file in `run_dir/.workflow_state.json`, stage-keyed; `force` re-runs | met | atomic tmp+rename writes; `force` invalidates transitive dependents (verified, incl. out-of-range `collect` marked `invalidated`) |
+| 10 | Missing prerequisites → error (safer default) | met | `WorkflowPrerequisiteError` naming the missing stages; verified; nothing executed before the error |
+| 11 | `step()` semantics kept or documented | met | docstring now explains time-stepping vs workflow stages (simulation.py:366-375) |
+| 12 | Tests: range runs, state records, second run skips, prerequisite error, full unchanged, stability test | met (stability test weak) | all 8 present and green; stability test is plan-swapping, not workflow-varying → m2 |
+| 13 | Docs: workflow/running-simulation documentation updated | partial | page added, but the resume-after-failure example is inaccurate → M1 |
+| 14 | Verification: `pytest quick/` green | met | re-ran: 185 passed, 2 xfailed, 1 xpassed (+3499 subtests) = 177 baseline + 8 new |
+| 15 | Verification: manual scenario (build; submit; collect; final artifacts identical to full run) | met | `test_incremental_stage_scenario` + independent scratch repro (probe A: final artifacts identical, marker flows build→submit→collect) |
+| 16 | Verification: Pre-commit green | missed | `require-ascii` fails on the branch's own `TASK-09-FINDINGS.md` → m1 |
+
+## 4. Claim verification (author artifact)
+
+| Claim (from TASK-09-FINDINGS.md / docs) | Re-verified? | Result / delta |
+|---|---|---|
+| `pytest quick/ -q`: 185 passed, 2 xfailed, 1 xpassed (baseline 177; +8 new tests) | yes | **Confirmed exactly** (185 passed, 2 xfailed, 1 xpassed, 3499 subtests; new file has 8 tests) |
+| `pre-commit run --all-files`: all hooks passed | yes | **FALSE** — `require-ascii` fails (exit 1) on `TASK-09-FINDINGS.md` itself, 19 em-dashes; all other hooks pass → m1 |
+| "The default plan mirrors the `in:`/`out:` bindings of `workflow.cwl` (steps, lines 112-155) exactly, incl. `destination_path`" | yes | **Confirmed** by parsing the real template and comparing every binding (scratch probe E) |
+| "Second no-arg run must not redo (or even rewrite) completed stages (state file byte-identical)" | yes | **Confirmed** — no state write happens on the all-completed path; file untouched |
+| "Stability test passed — adapter absorbs a step inserted inside an existing stage without any API change" | yes | Passes, but the test varies the *plan*, not the workflow (tautological) → m2; the real workflow-change modes were probed in scratch (step-id rename transparent; step-file rename fails loudly; extra workflow step → silent full/partial divergence) |
+| Doc: "first attempt failed inside 'submit' … after fixing the problem: only 'submit' and 'collect' are re-run" (`partial_workflow.rst:74-82`) | yes | **FALSE for the default call** — a failed default run leaves no state file; second call re-runs the full workflow, job-cache permitting → M1 |
+| "Previously a second `picongpu_run()` crashed in `generate()`'s assert; it now resumes" | yes | **Confirmed** — second call no longer crashes; it skips completed stages |
+| "Flags after generation raise a clear `ValueError`; the state is left intact" | yes | **Confirmed** (scratch probe + test 7) |
+| §9 "default (no args) = full pipeline, backward compatible" / "single cwltool invocation … byte-for-byte the full workflow as today" | yes | **Confirmed for fresh runs** (legacy path = single `workflow.cwl` invocation; only additive: the state file written afterwards) |
+| §13 "the `docs/source/python_package/` pages from PR 5731 do not exist on this lineage" | yes | **Confirmed** — directory absent |
+| §14 open questions still genuinely open | yes | All 7 are honestly deferred, not silently decided in code (each has a chosen default implemented + listed alternative) |
+| §5 "per-step submit … stable for partial runs exactly as for the full run" | yes (partially) | Path stability: **confirmed** (same `destination_path` flows into per-step submit). But see FYI: for the default `bash` preset this wording understates the submit→collect staging-ordering hazard, which partial execution turns from a race into a deterministic failure |
+
+## 5. Design discussion
+
+**Option choice (per-step cwltool vs sub-workflow generation).** Per-step
+invocation through the existing `cwltool.factory` is the right call for this
+codebase: the steps are already self-contained tools, the default path stays
+byte-for-byte the historical single invocation, and the wiring becomes small
+declarative data (`StageStepSpec.inputs`) that is inspectable and testable.
+Sub-workflow generation (option 2) would require hand-writing CWL serialization
+and would change the default path too. The cost of option 1 — re-implementing
+step→step wiring in Python — is real but bounded; the missing complement is a
+**plan↔workflow sync test** (m2), which would turn "keep the adapter in sync"
+from a tribal obligation into a CI-enforced invariant. A maintainer weighing
+this should also note that per-step execution deliberately bypasses
+`workflow.cwl` validation: a workflow.cwl change that breaks only the full-run
+path (or only the per-step path) is possible today.
+
+**Stability mechanism.** The core promise is genuinely achieved at the levels
+that matter: the API, the state file, and the on-disk layout (`step-N`
+numbered outdirs) contain no CWL step names, so step *id* renames and step
+*reordering/insertion within a stage* are transparent (verified in scratch:
+renamed step ids → both full and partial runs unaffected; author's in-stage
+insertion → works). The stable boundary is the `Stage` enum + plan data. What
+the design does *not* guarantee — and should document — is that the plan
+tracks the templates automatically; that is a maintainer update, currently
+untested (m2). The "membership may grow, meaning is stable" contract in the
+`Stage` docstring is the right statement.
+
+**Resume semantics and the state file's blind spots.** Two asymmetries are
+worth a maintainer's attention. First, the state is only populated by
+per-step execution or by a *successful* single invocation (M1): a failed
+default run is invisible to the state layer, and resume falls back to the
+cwltool job cache, which is keyed by input bytes — so "the fix" (changed
+inputs) defeats it. Second, the state is authoritative about *nothing*
+regarding inputs (M2): there is no fingerprint tying recorded artifacts to the
+`input.yaml` that produced them. Together these make "skip completed stages"
+a pure status lookup. The cwltool cache had exactly the missing property
+(input-keyed); the draft keeps it as a "safety net" for job reuse but the
+stage layer bypasses it for skip decisions. Input fingerprinting (sketch in
+M2) is the minimal fix that makes the state layer honest.
+
+**Force/invalidation.** Transitive dependent invalidation is the correct
+default (new binaries ⇒ stale job results), persisting `invalidated` status
+keeps the state auditable, and out-of-range invalidated stages are marked but
+not executed — all verified. The one question left for the requester (§14.3)
+is legitimate; the implemented default is defensible.
+
+**Interaction with task 05 (see FYI).** The per-step submit passes the same
+stable `destination_path` (run dir) as the full run, so task-05's root-cause
+fix carries over to partial runs — that part works. What does not carry over
+cleanly is the *ordering* assumption: for the default `bash` preset the
+submitted background job needs `$TBG_dstPath/input/bin`, which only
+`collect`/`organize_output` stages into the run dir. The full workflow hides
+this in a race; "submit now, collect later" — the task's own use case — makes
+it deterministic. The draft neither acknowledges nor mitigates this; at a
+minimum the docs/FINDINGS should, and a later iteration might move the
+`input/` staging ahead of job launch (e.g. into the submit stage) for local
+presets.
+
+## 6. Prioritized next steps
+
+1. Fix the false resume documentation (M1): rewrite
+   `partial_workflow.rst:66-82` with a range-based failure/resume example,
+   state explicitly that a failed *default* run resumes only via the cwltool
+   job cache when inputs are unchanged, and align the CHANGELOG sentence.
+2. Add input-change detection to the state (M2): per-stage (or global)
+   `inputs_digest` in `.workflow_state.json`, invalidating `completed` stages
+   whose inputs changed, with a logged warning — or, minimally, treat the
+   no-arg all-completed case as "re-run the legacy full workflow" so changed
+   inputs are never silently ignored.
+3. Make pre-commit actually green (m1): ASCII-ify `TASK-09-FINDINGS.md` and
+   run `pre-commit run --all-files` before re-claiming it in §12.
+4. Add the plan↔workflow sync test and re-frame the stability test around a
+   mutated scratch `workflow.cwl` (m2).
+5. Wrap cwltool load/validation errors in `WorkflowStageError` (m3).
+6. Nits: implement or drop the state `version` check (n1); make
+   `run_range`'s return consistent across both paths (n2).
+7. Before graduating from draft: resolve the §14 open questions with the
+   requester, and add the task-05 `bash`-preset staging-ordering caveat to the
+   docs (FYI below).
+
+## FYI (inherited from base, not scored here)
+
+- **Task-05 C1 impact (assessed as requested).** With the default `bash`
+  submit system the generated `submit.start`
+  (`etc/picongpu/bash/mpiexec.tpl:36,56`) does `cd $TBG_dstPath` and runs
+  `$TBG_dstPath/input/bin/picongpu`; `$TBG_dstPath` is the run dir (task-05's
+  `destination_path`), and `run_dir/input/` is created only by
+  `organize_output` (collect). In the full workflow this is the race flagged
+  in task 05's review (inherited, not re-scored). Task-09's stage interface
+  *widen*s it: verified in scratch that after `run_range(up_to=Stage.submit)`
+  (no collect) `run_dir/input` does not exist, so for the `bash` preset the
+  background job deterministically cannot find its binary — the "submit after
+  an out-of-band build" / "organize_output after manual intervention" use
+  cases fail for local runs unless `collect` follows immediately or the user
+  stages `input/` by hand. The draft's FINDINGS §5 claim that partial submit
+  is "exactly as for the full run" is optimistic in this respect. HPC presets
+  have the related (pre-existing) issue that `$TBG_dstPath` must already hold
+  the input files on the cluster — one of the future "remote execution steps"
+  the stage design anticipates.
+- The branch's edits to the inherited `TASK-05-PR-PROPOSAL.md` (em-dash →
+  hyphen normalization) are disclosed in FINDINGS §12 and harmless; they exist
+  because the base branch itself fails `require-ascii`.
+- Pre-existing stale hooks `run_step_path`/`gather_results_script_path` and
+  the class docstring's phantom `build()` are correctly left untouched and
+  listed as deferred (FINDINGS §11) — agreed.

--- a/TASK-09-REVIEW.md
+++ b/TASK-09-REVIEW.md
@@ -1,14 +1,23 @@
-# Review — Task 09: Partial Workflow Execution (Stable Stage Interface)
+# Review - Task 09: Partial Workflow Execution (Stable Stage Interface)
 
 - **Branch:** `task-09-partial-workflow` (tip `7e6e67bd8`, base `task-05-cwl-cache-ref-purge` @ `33d89313f`)
-- **Reviewed:** 2026-08-31 · **Scope:** 7 commits, 11 files, +1572/−19
+- **Reviewed:** 2026-08-31 - **Scope:** 7 commits, 11 files, +1572/-19
 - **Verdict:** REQUEST CHANGES
-  (Sound design and a working draft, but the artifact contains two false claims — a failed "pre-commit green" and a doc example that misdescribes the flagship resume behavior — plus a silent-no-op hazard on changed inputs.)
+  (Sound design and a working draft, but the artifact contains two false claims - a failed "pre-commit green" and a doc example that misdescribes the flagship resume behavior - plus a silent-no-op hazard on changed inputs.)
+
+> **Rework (2026-09-02).** The base task-05 was reworked to the step-isolation
+> model and `destination_path` was removed (`971db962a`); task-09 is now
+> rebased onto it. References in this review to `destination_path` and to the
+> submit step pre-staging into the run dir (section 4, section 5 "Interaction
+> with task 05", the FYI "Task-05 C1 impact") therefore describe the prior base
+> state and are superseded. The stage interface, state file, and tests are
+> otherwise unchanged. See `TASK-09-RESPONSE.md` (rework section) and the PR
+> #13 comment.
 
 ## 1. Summary
 
 The branch adds a `Stage` vocabulary (`build`/`prepare`/`submit`/`collect`), a
-data-driven stage→CWL-step adapter (`StagePlan`/`DEFAULT_STAGE_PLAN`), a
+data-driven stage->CWL-step adapter (`StagePlan`/`DEFAULT_STAGE_PLAN`), a
 stage-keyed persisted state file (`run_dir/.workflow_state.json`), and
 `Runner.run_range(up_to/from_/force)` exposed as
 `Simulation.picongpu_run(up_to=..., from_=..., force=...)`. Scope is
@@ -21,7 +30,7 @@ and the state/on-disk layout is genuinely step-name-free. The main problems:
 (1) a failed *default* (no-arg) run records no stage state at all, so the
 documented "resume after a failed run" example is false for the most common
 entry point; (2) the state has no link to the inputs that produced the
-artifacts — after any completed run, editing `input.yaml` and calling
+artifacts - after any completed run, editing `input.yaml` and calling
 `picongpu_run()` silently does nothing and reuses stale artifacts; (3) the
 "pre-commit green" claim is false (the author's own `TASK-09-FINDINGS.md`
 fails `require-ascii`).
@@ -34,24 +43,24 @@ None found.
 
 ### 2.2 Major
 
-**M1** — **`docs/source/usage/picmi/partial_workflow.rst:66-82`** (and the
-same wording in `CHANGELOG.md:12`) — the flagship "resume after a failed run"
+**M1** - **`docs/source/usage/picmi/partial_workflow.rst:66-82`** (and the
+same wording in `CHANGELOG.md:12`) - the flagship "resume after a failed run"
 story does not hold for the default (no-arg) call, and the doc example asserts
 it does.
 - The example shows `sim.picongpu_run()` failing inside `submit`, then a
   second `sim.picongpu_run()` where "only 'submit' and 'collect' are re-run".
   That is false: the legacy full-run path records state **only after
-  success** — `run_range` calls `self._record_full_run(state, outputs)`
+  success** - `run_range` calls `self._record_full_run(state, outputs)`
   (runner.py:967-968) only after `self.run()` returns. A failed default run
   leaves **no state file at all**, so the second call sees an empty state,
   takes the legacy path again, and re-runs the whole `workflow.cwl`.
-  `build`/`prepare` are skipped only if cwltool's job cache hits — i.e. only
+  `build`/`prepare` are skipped only if cwltool's job cache hits - i.e. only
   when the "fix" did not change any input, which is usually not the case.
   - *Evidence:* scratch repro (`/tmp/opencode/review-09/probe_i.py`): failing
-    `submit` dummy, `sim.picongpu_run()` → raises `WorkflowStatus`; afterwards
+    `submit` dummy, `sim.picongpu_run()` -> raises `WorkflowStatus`; afterwards
     `run_dir/.workflow_state.json` **does not exist** (only `.cwl_cache` with
     6 job entries). Stage-level resume *does* work for range-started runs
-    (verified: `up_to=submit` fails → no-arg resume re-ran only submit+collect,
+    (verified: `up_to=submit` fails -> no-arg resume re-ran only submit+collect,
     build/prepare untouched), so the feature exists but the documented
     default-call example is wrong.
   - *Suggested fix:* (a) Rewrite the doc section: state that stage-level resume
@@ -63,11 +72,11 @@ it does.
   - *Alternative:* if stage-level resume after a failed default run is wanted,
     the default path would need per-step progress during the single cwltool
     invocation (e.g. always drive stages individually, or poll the job cache)
-    — both change the "default = single invocation" invariant, so for a draft
+    - both change the "default = single invocation" invariant, so for a draft
     the honest documentation is the right call.
 
-**M2** — **`lib/python/picongpu/pypicongpu/runner.py:998-1002`** (skip loop) +
-`picongpu_run` (simulation.py:527-535) — the persisted state carries no
+**M2** - **`lib/python/picongpu/pypicongpu/runner.py:998-1002`** (skip loop) +
+`picongpu_run` (simulation.py:527-535) - the persisted state carries no
 fingerprint of the inputs that produced the recorded artifacts, so a run whose
 inputs changed is silently skipped, reusing stale artifacts.
 - After a completed run, `completed` stages are unconditionally skipped
@@ -75,12 +84,12 @@ inputs changed is silently skipped, reusing stale artifacts.
   inputs. The public API correctly rejects flag changes after generation
   (simulation.py:530-534), but `workflow/input.yaml` is a plain file the user
   may edit (the `build_`/`run_` prefix convention exists precisely "in cases
-  when one wants to run the steps individually", runner.py:606-608) — and
+  when one wants to run the steps individually", runner.py:606-608) - and
   editing it invalidates the state with zero detection.
   - *Evidence:* scratch repro (`/tmp/opencode/review-09/probe_a.py`, probe B):
-    full run → edit `build_cmake` in `input.yaml` to `"v2"` →
+    full run -> edit `build_cmake` in `input.yaml` to `"v2"` ->
     `sim.picongpu_run()` returns `None`, state file byte-identical, and the
-    final `input/bin/picongpu` still contains `built-default` — the user gets
+    final `input/bin/picongpu` still contains `built-default` - the user gets
     no indication that their input change was ignored and the simulation was
     *not* re-run.
   - *Suggested fix:* store an input fingerprint per stage (or globally) in the
@@ -90,34 +99,34 @@ inputs changed is silently skipped, reusing stale artifacts.
     in `_run_stage` / `_record_full_run` (the consumed inputs are exactly the
     string-sourced entries of the step specs, resolvable in
     `_resolve_step_inputs`). In `run_range`, after loading state, recompute the
-    digest from `workflow_input_path` and downgrade `completed` →
+    digest from `workflow_input_path` and downgrade `completed` ->
     `invalidated` (with a logged message) for stages whose digest no longer
     matches. Coarse variant: one digest of the whole `input.yaml`; any change
-    invalidates all stages — simpler, still eliminates the silent no-op.
+    invalidates all stages - simpler, still eliminates the silent no-op.
   - *Alternative:* for the no-arg all-completed case, fall back to the legacy
-    `self.run()` path and let the cwltool cache decide what to skip —
-    restores "call again → it re-runs (cheaply) when inputs changed" without
+    `self.run()` path and let the cwltool cache decide what to skip -
+    restores "call again -> it re-runs (cheaply) when inputs changed" without
     fingerprinting, but loses stage granularity and changes the observed
     behavior of an up-to-date re-run from no-op to cache-checked re-run.
 
 ### 2.3 Minor
 
-**m1** — **`TASK-09-FINDINGS.md` (19 occurrences, e.g. :48, :363, :384)** — the
-claim "`pre-commit run --all-files`: all hooks passed" (§12) is false; the
+**m1** - **`TASK-09-FINDINGS.md` (19 occurrences, e.g. :48, :363, :384)** - the
+claim "`pre-commit run --all-files`: all hooks passed" (section 12) is false; the
 task's "Verification: Pre-commit green" is not met.
 - *Evidence:* `/tmp/opencode/venvs/task-09/bin/pre-commit run --files <all 11
-  changed files>` → `require-ascii` **Failed, exit 1** on
-  `TASK-09-FINDINGS.md` (19 em-dashes `—`). All other hooks pass (ruff,
-  ruff-format, trailing-whitespace, end-of-file-fixer, …). Ironic detail: the
+  changed files>` -> `require-ascii` **Failed, exit 1** on
+  `TASK-09-FINDINGS.md` (19 em-dashes `-`). All other hooks pass (ruff,
+  ruff-format, trailing-whitespace, end-of-file-fixer, ...). Ironic detail: the
   branch *did* fix the inherited `TASK-05-PR-PROPOSAL.md` em-dashes to make the
-  hook pass, but left the new artifact doc non-ASCII — so `--all-files`
+  hook pass, but left the new artifact doc non-ASCII - so `--all-files`
   fails on the file this very branch added.
-  - *Suggested fix:* ASCII-ify `TASK-09-FINDINGS.md` (same `—`→`-`
+  - *Suggested fix:* ASCII-ify `TASK-09-FINDINGS.md` (same `-`->`-`
     normalization as in `TASK-05-PR-PROPOSAL.md`) and actually run
-    `pre-commit run --all-files` before claiming it in §12.
+    `pre-commit run --all-files` before claiming it in section 12.
 
-**m2** — **`lib/python/picongpu/pypicongpu/runner.py:261-351`**
-(`DEFAULT_STAGE_PLAN`) + `lib/python/test/picongpu/quick/picmi/test_partial_workflow.py:442-466` —
+**m2** - **`lib/python/picongpu/pypicongpu/runner.py:261-351`**
+(`DEFAULT_STAGE_PLAN`) + `lib/python/test/picongpu/quick/picmi/test_partial_workflow.py:442-466` -
 nothing verifies the plan against the real `workflow.cwl`, and the "stability
 test" is tautological.
 - The adapter is by design "the single place that knows the current CWL
@@ -128,14 +137,14 @@ test" is tautological.
   - *Evidence:* scratch probes (`/tmp/opencode/review-09/probe_def.py`):
     (a) current plan *is* in sync (all plan step files exist in the template;
     all plan workflow-input names are defined in `workflow.cwl`; step-output
-    refs map to the right producing stages — verified by parsing
+    refs map to the right producing stages - verified by parsing
     `templates/workflow/workflow.cwl`), so no live bug; (b) inserting a 5th
     `validate_step` into a scratch `workflow.cwl` runs it in the full run but
-    the per-step resume never runs it again — silent divergence; (c) the
+    the per-step resume never runs it again - silent divergence; (c) the
     shipped stability test only reassigns `runner.stage_plan` with a synthetic
     plan, i.e. it proves "the code accepts a different plan", not that the
     default plan survives a workflow change. (Renaming CWL step *ids* is in
-    fact transparent — verified in scratch — because per-step execution
+    fact transparent - verified in scratch - because per-step execution
     bypasses `workflow.cwl`.)
   - *Suggested fix:* add a test that loads the *real*
     `templates/workflow/workflow.cwl` (yaml) and asserts, for every plan step
@@ -148,11 +157,11 @@ test" is tautological.
     exercises the actual failure mode (plan/workflow drift) instead of
     self-consistency.
 
-**m3** — **`lib/python/picongpu/pypicongpu/runner.py:839-855`** (`_run_cwl_step`) —
+**m3** - **`lib/python/picongpu/pypicongpu/runner.py:839-855`** (`_run_cwl_step`) -
 only `WorkflowStatus` is caught, so cwltool *load/validation* failures surface
 as raw `cwltool` exceptions instead of the documented `WorkflowStageError`.
-- *Evidence:* scratch probe: rename `steps/build.cwl` → `compile.cwl` in a
-  scratch setup (plan unchanged) → `run_range(up_to=Stage.build)` raises
+- *Evidence:* scratch probe: rename `steps/build.cwl` -> `compile.cwl` in a
+  scratch setup (plan unchanged) -> `run_range(up_to=Stage.build)` raises
   `cwltool...ValidationException`, not `WorkflowStageError`; the failure is
   loud (good), but the error contract stated in the docstrings ("wrapped in
   `WorkflowStageError` for cwltool failures") does not hold for the most
@@ -165,13 +174,13 @@ as raw `cwltool` exceptions instead of the documented `WorkflowStageError`.
 
 ### 2.4 Nits
 
-**n1** — **`lib/python/picongpu/pypicongpu/runner.py:386`** — the state
+**n1** - **`lib/python/picongpu/pypicongpu/runner.py:386`** - the state
 `version` field is never consulted (probe: a state file with `version: 99`
 loads without comment). It is a placeholder for migration logic that does not
 exist; either implement a check (reject/`reset` on unknown version) or drop
 the field until it means something.
 
-**n2** — **`lib/python/picongpu/pypicongpu/runner.py:965-969` vs `:997-1003`** —
+**n2** - **`lib/python/picongpu/pypicongpu/runner.py:965-969` vs `:997-1003`** -
 `run_range`'s return value is shape-inconsistent: the legacy path returns the
 full-workflow outputs dict, the per-step path returns the last executed
 stage's artifacts or `None`. Inconsequential through `picongpu_run` (which
@@ -182,39 +191,39 @@ last executed stage, or None") is violated by the legacy branch.
 
 | # | Requirement (from task file) | Status | Where / note |
 |---|---|---|---|
-| 1 | PICMI-level interface to execute subsets of the CWL workflow | met | `picongpu_run(up_to/from_/force)` (simulation.py:506-535) → `Runner.run_range` (runner.py:930-1003) |
-| 2 | Resume after a failed/partial run without redoing successful steps | partial | Works for range-started runs (verified); a failed *default* run records no state, and the doc example claiming otherwise is false → M1 |
-| 3 | Run `build` without `submit` / `submit` after out-of-band build / `organize_output` after manual intervention | met (API level) | `up_to=Stage.build`, `from_=Stage.submit`, `force=Stage.collect`; real-`bash`-preset staging caveat → FYI |
+| 1 | PICMI-level interface to execute subsets of the CWL workflow | met | `picongpu_run(up_to/from_/force)` (simulation.py:506-535) -> `Runner.run_range` (runner.py:930-1003) |
+| 2 | Resume after a failed/partial run without redoing successful steps | partial | Works for range-started runs (verified); a failed *default* run records no state, and the doc example claiming otherwise is false -> M1 |
+| 3 | Run `build` without `submit` / `submit` after out-of-band build / `organize_output` after manual intervention | met (API level) | `up_to=Stage.build`, `from_=Stage.submit`, `force=Stage.collect`; real-`bash`-preset staging caveat -> FYI |
 | 4 | Implemented in the Python package, with tests, and documented | met | 8 tests (`test_partial_workflow.py`), `partial_workflow.rst` + toctree + cross-ref |
-| 5 | Public interface must NOT address CWL steps by name (stable across step number/name changes) | met | State keyed by stage, outdirs `step-N` numbered; step-id renames verified transparent (scratch probe F1); plan is the single internal change point, but unvalidated → m2 |
+| 5 | Public interface must NOT address CWL steps by name (stable across step number/name changes) | met | State keyed by stage, outdirs `step-N` numbered; step-id renames verified transparent (scratch probe F1); plan is the single internal change point, but unvalidated -> m2 |
 | 6 | Python API only (no CLI) | met | diff touches only `lib/python` + docs/CHANGELOG/task md; no CLI, no C++/templates |
-| 7 | Explore solution space → best option → draft implementation | met | FINDINGS §5 compares per-step vs sub-workflow vs flags-only, recommends per-step with trade-offs |
-| 8 | Stage→step adapter as the single place knowing the current steps | met (partial) | `StagePlan`/`DEFAULT_STAGE_PLAN` (runner.py:233-351); currently in sync with the template (verified) but no sync test → m2 |
+| 7 | Explore solution space -> best option -> draft implementation | met | FINDINGS section 5 compares per-step vs sub-workflow vs flags-only, recommends per-step with trade-offs |
+| 8 | Stage->step adapter as the single place knowing the current steps | met (partial) | `StagePlan`/`DEFAULT_STAGE_PLAN` (runner.py:233-351); currently in sync with the template (verified) but no sync test -> m2 |
 | 9 | State file in `run_dir/.workflow_state.json`, stage-keyed; `force` re-runs | met | atomic tmp+rename writes; `force` invalidates transitive dependents (verified, incl. out-of-range `collect` marked `invalidated`) |
-| 10 | Missing prerequisites → error (safer default) | met | `WorkflowPrerequisiteError` naming the missing stages; verified; nothing executed before the error |
+| 10 | Missing prerequisites -> error (safer default) | met | `WorkflowPrerequisiteError` naming the missing stages; verified; nothing executed before the error |
 | 11 | `step()` semantics kept or documented | met | docstring now explains time-stepping vs workflow stages (simulation.py:366-375) |
-| 12 | Tests: range runs, state records, second run skips, prerequisite error, full unchanged, stability test | met (stability test weak) | all 8 present and green; stability test is plan-swapping, not workflow-varying → m2 |
-| 13 | Docs: workflow/running-simulation documentation updated | partial | page added, but the resume-after-failure example is inaccurate → M1 |
+| 12 | Tests: range runs, state records, second run skips, prerequisite error, full unchanged, stability test | met (stability test weak) | all 8 present and green; stability test is plan-swapping, not workflow-varying -> m2 |
+| 13 | Docs: workflow/running-simulation documentation updated | partial | page added, but the resume-after-failure example is inaccurate -> M1 |
 | 14 | Verification: `pytest quick/` green | met | re-ran: 185 passed, 2 xfailed, 1 xpassed (+3499 subtests) = 177 baseline + 8 new |
-| 15 | Verification: manual scenario (build; submit; collect; final artifacts identical to full run) | met | `test_incremental_stage_scenario` + independent scratch repro (probe A: final artifacts identical, marker flows build→submit→collect) |
-| 16 | Verification: Pre-commit green | missed | `require-ascii` fails on the branch's own `TASK-09-FINDINGS.md` → m1 |
+| 15 | Verification: manual scenario (build; submit; collect; final artifacts identical to full run) | met | `test_incremental_stage_scenario` + independent scratch repro (probe A: final artifacts identical, marker flows build->submit->collect) |
+| 16 | Verification: Pre-commit green | missed | `require-ascii` fails on the branch's own `TASK-09-FINDINGS.md` -> m1 |
 
 ## 4. Claim verification (author artifact)
 
 | Claim (from TASK-09-FINDINGS.md / docs) | Re-verified? | Result / delta |
 |---|---|---|
 | `pytest quick/ -q`: 185 passed, 2 xfailed, 1 xpassed (baseline 177; +8 new tests) | yes | **Confirmed exactly** (185 passed, 2 xfailed, 1 xpassed, 3499 subtests; new file has 8 tests) |
-| `pre-commit run --all-files`: all hooks passed | yes | **FALSE** — `require-ascii` fails (exit 1) on `TASK-09-FINDINGS.md` itself, 19 em-dashes; all other hooks pass → m1 |
+| `pre-commit run --all-files`: all hooks passed | yes | **FALSE** - `require-ascii` fails (exit 1) on `TASK-09-FINDINGS.md` itself, 19 em-dashes; all other hooks pass -> m1 |
 | "The default plan mirrors the `in:`/`out:` bindings of `workflow.cwl` (steps, lines 112-155) exactly, incl. `destination_path`" | yes | **Confirmed** by parsing the real template and comparing every binding (scratch probe E) |
-| "Second no-arg run must not redo (or even rewrite) completed stages (state file byte-identical)" | yes | **Confirmed** — no state write happens on the all-completed path; file untouched |
-| "Stability test passed — adapter absorbs a step inserted inside an existing stage without any API change" | yes | Passes, but the test varies the *plan*, not the workflow (tautological) → m2; the real workflow-change modes were probed in scratch (step-id rename transparent; step-file rename fails loudly; extra workflow step → silent full/partial divergence) |
-| Doc: "first attempt failed inside 'submit' … after fixing the problem: only 'submit' and 'collect' are re-run" (`partial_workflow.rst:74-82`) | yes | **FALSE for the default call** — a failed default run leaves no state file; second call re-runs the full workflow, job-cache permitting → M1 |
-| "Previously a second `picongpu_run()` crashed in `generate()`'s assert; it now resumes" | yes | **Confirmed** — second call no longer crashes; it skips completed stages |
+| "Second no-arg run must not redo (or even rewrite) completed stages (state file byte-identical)" | yes | **Confirmed** - no state write happens on the all-completed path; file untouched |
+| "Stability test passed - adapter absorbs a step inserted inside an existing stage without any API change" | yes | Passes, but the test varies the *plan*, not the workflow (tautological) -> m2; the real workflow-change modes were probed in scratch (step-id rename transparent; step-file rename fails loudly; extra workflow step -> silent full/partial divergence) |
+| Doc: "first attempt failed inside 'submit' ... after fixing the problem: only 'submit' and 'collect' are re-run" (`partial_workflow.rst:74-82`) | yes | **FALSE for the default call** - a failed default run leaves no state file; second call re-runs the full workflow, job-cache permitting -> M1 |
+| "Previously a second `picongpu_run()` crashed in `generate()`'s assert; it now resumes" | yes | **Confirmed** - second call no longer crashes; it skips completed stages |
 | "Flags after generation raise a clear `ValueError`; the state is left intact" | yes | **Confirmed** (scratch probe + test 7) |
-| §9 "default (no args) = full pipeline, backward compatible" / "single cwltool invocation … byte-for-byte the full workflow as today" | yes | **Confirmed for fresh runs** (legacy path = single `workflow.cwl` invocation; only additive: the state file written afterwards) |
-| §13 "the `docs/source/python_package/` pages from PR 5731 do not exist on this lineage" | yes | **Confirmed** — directory absent |
-| §14 open questions still genuinely open | yes | All 7 are honestly deferred, not silently decided in code (each has a chosen default implemented + listed alternative) |
-| §5 "per-step submit … stable for partial runs exactly as for the full run" | yes (partially) | Path stability: **confirmed** (same `destination_path` flows into per-step submit). But see FYI: for the default `bash` preset this wording understates the submit→collect staging-ordering hazard, which partial execution turns from a race into a deterministic failure |
+| section 9 "default (no args) = full pipeline, backward compatible" / "single cwltool invocation ... byte-for-byte the full workflow as today" | yes | **Confirmed for fresh runs** (legacy path = single `workflow.cwl` invocation; only additive: the state file written afterwards) |
+| section 13 "the `docs/source/python_package/` pages from PR 5731 do not exist on this lineage" | yes | **Confirmed** - directory absent |
+| section 14 open questions still genuinely open | yes | All 7 are honestly deferred, not silently decided in code (each has a chosen default implemented + listed alternative) |
+| section 5 "per-step submit ... stable for partial runs exactly as for the full run" | yes (partially) | Path stability: **confirmed** (same `destination_path` flows into per-step submit). But see FYI: for the default `bash` preset this wording understates the submit->collect staging-ordering hazard, which partial execution turns from a race into a deterministic failure |
 
 ## 5. Design discussion
 
@@ -224,9 +233,9 @@ codebase: the steps are already self-contained tools, the default path stays
 byte-for-byte the historical single invocation, and the wiring becomes small
 declarative data (`StageStepSpec.inputs`) that is inspectable and testable.
 Sub-workflow generation (option 2) would require hand-writing CWL serialization
-and would change the default path too. The cost of option 1 — re-implementing
-step→step wiring in Python — is real but bounded; the missing complement is a
-**plan↔workflow sync test** (m2), which would turn "keep the adapter in sync"
+and would change the default path too. The cost of option 1 - re-implementing
+step->step wiring in Python - is real but bounded; the missing complement is a
+**plan<->workflow sync test** (m2), which would turn "keep the adapter in sync"
 from a tribal obligation into a CI-enforced invariant. A maintainer weighing
 this should also note that per-step execution deliberately bypasses
 `workflow.cwl` validation: a workflow.cwl change that breaks only the full-run
@@ -236,9 +245,9 @@ path (or only the per-step path) is possible today.
 that matter: the API, the state file, and the on-disk layout (`step-N`
 numbered outdirs) contain no CWL step names, so step *id* renames and step
 *reordering/insertion within a stage* are transparent (verified in scratch:
-renamed step ids → both full and partial runs unaffected; author's in-stage
-insertion → works). The stable boundary is the `Stage` enum + plan data. What
-the design does *not* guarantee — and should document — is that the plan
+renamed step ids -> both full and partial runs unaffected; author's in-stage
+insertion -> works). The stable boundary is the `Stage` enum + plan data. What
+the design does *not* guarantee - and should document - is that the plan
 tracks the templates automatically; that is a maintainer update, currently
 untested (m2). The "membership may grow, meaning is stable" contract in the
 `Stage` docstring is the right statement.
@@ -247,7 +256,7 @@ untested (m2). The "membership may grow, meaning is stable" contract in the
 worth a maintainer's attention. First, the state is only populated by
 per-step execution or by a *successful* single invocation (M1): a failed
 default run is invisible to the state layer, and resume falls back to the
-cwltool job cache, which is keyed by input bytes — so "the fix" (changed
+cwltool job cache, which is keyed by input bytes - so "the fix" (changed
 inputs) defeats it. Second, the state is authoritative about *nothing*
 regarding inputs (M2): there is no fingerprint tying recorded artifacts to the
 `input.yaml` that produced them. Together these make "skip completed stages"
@@ -257,18 +266,18 @@ stage layer bypasses it for skip decisions. Input fingerprinting (sketch in
 M2) is the minimal fix that makes the state layer honest.
 
 **Force/invalidation.** Transitive dependent invalidation is the correct
-default (new binaries ⇒ stale job results), persisting `invalidated` status
+default (new binaries => stale job results), persisting `invalidated` status
 keeps the state auditable, and out-of-range invalidated stages are marked but
-not executed — all verified. The one question left for the requester (§14.3)
+not executed - all verified. The one question left for the requester (section 14.3)
 is legitimate; the implemented default is defensible.
 
 **Interaction with task 05 (see FYI).** The per-step submit passes the same
 stable `destination_path` (run dir) as the full run, so task-05's root-cause
-fix carries over to partial runs — that part works. What does not carry over
+fix carries over to partial runs - that part works. What does not carry over
 cleanly is the *ordering* assumption: for the default `bash` preset the
 submitted background job needs `$TBG_dstPath/input/bin`, which only
 `collect`/`organize_output` stages into the run dir. The full workflow hides
-this in a race; "submit now, collect later" — the task's own use case — makes
+this in a race; "submit now, collect later" - the task's own use case - makes
 it deterministic. The draft neither acknowledges nor mitigates this; at a
 minimum the docs/FINDINGS should, and a later iteration might move the
 `input/` staging ahead of job launch (e.g. into the submit stage) for local
@@ -282,17 +291,17 @@ presets.
    job cache when inputs are unchanged, and align the CHANGELOG sentence.
 2. Add input-change detection to the state (M2): per-stage (or global)
    `inputs_digest` in `.workflow_state.json`, invalidating `completed` stages
-   whose inputs changed, with a logged warning — or, minimally, treat the
+   whose inputs changed, with a logged warning - or, minimally, treat the
    no-arg all-completed case as "re-run the legacy full workflow" so changed
    inputs are never silently ignored.
 3. Make pre-commit actually green (m1): ASCII-ify `TASK-09-FINDINGS.md` and
-   run `pre-commit run --all-files` before re-claiming it in §12.
-4. Add the plan↔workflow sync test and re-frame the stability test around a
+   run `pre-commit run --all-files` before re-claiming it in section 12.
+4. Add the plan<->workflow sync test and re-frame the stability test around a
    mutated scratch `workflow.cwl` (m2).
 5. Wrap cwltool load/validation errors in `WorkflowStageError` (m3).
 6. Nits: implement or drop the state `version` check (n1); make
    `run_range`'s return consistent across both paths (n2).
-7. Before graduating from draft: resolve the §14 open questions with the
+7. Before graduating from draft: resolve the section 14 open questions with the
    requester, and add the task-05 `bash`-preset staging-ordering caveat to the
    docs (FYI below).
 
@@ -307,17 +316,17 @@ presets.
   in task 05's review (inherited, not re-scored). Task-09's stage interface
   *widen*s it: verified in scratch that after `run_range(up_to=Stage.submit)`
   (no collect) `run_dir/input` does not exist, so for the `bash` preset the
-  background job deterministically cannot find its binary — the "submit after
+  background job deterministically cannot find its binary - the "submit after
   an out-of-band build" / "organize_output after manual intervention" use
   cases fail for local runs unless `collect` follows immediately or the user
-  stages `input/` by hand. The draft's FINDINGS §5 claim that partial submit
+  stages `input/` by hand. The draft's FINDINGS section 5 claim that partial submit
   is "exactly as for the full run" is optimistic in this respect. HPC presets
   have the related (pre-existing) issue that `$TBG_dstPath` must already hold
-  the input files on the cluster — one of the future "remote execution steps"
+  the input files on the cluster - one of the future "remote execution steps"
   the stage design anticipates.
-- The branch's edits to the inherited `TASK-05-PR-PROPOSAL.md` (em-dash →
-  hyphen normalization) are disclosed in FINDINGS §12 and harmless; they exist
+- The branch's edits to the inherited `TASK-05-PR-PROPOSAL.md` (em-dash ->
+  hyphen normalization) are disclosed in FINDINGS section 12 and harmless; they exist
   because the base branch itself fails `require-ascii`.
 - Pre-existing stale hooks `run_step_path`/`gather_results_script_path` and
   the class docstring's phantom `build()` are correctly left untouched and
-  listed as deferred (FINDINGS §11) — agreed.
+  listed as deferred (FINDINGS section 11) - agreed.

--- a/docs/source/usage/picmi/index.rst
+++ b/docs/source/usage/picmi/index.rst
@@ -19,4 +19,5 @@ PIConGPU supports `PICMI <https://picmi-standard.github.io/>`_ to create simulat
    :maxdepth: 1
 
    intro
+   partial_workflow
    custom_template

--- a/docs/source/usage/picmi/intro.rst
+++ b/docs/source/usage/picmi/intro.rst
@@ -141,6 +141,10 @@ Parameters/Methods prefixed with ``picongpu_`` are PIConGPU-exclusive.
     convert the PICMI simulation object to an equivalent :ref:`PyPIConGPU <PyPIConGPU_Intro>` simulation object.
   - ``picongpu_get_runner()``:
     Retrieve a :ref:`PyPIConGPU Runner <pypicongpu-running>` for running a PIConGPU simulation from Python, **not recommended, see :ref:`PICMI setup generation <generating_setups_with_PICMI>`**.
+  - ``picongpu_run(up_to=..., from_=..., force=...)``:
+    build and run the simulation, optionally executing only a subset of the
+    workflow stages (build/prepare/submit/collect) and resuming previously
+    completed stages, see :ref:`Partial Workflow Execution (Stages) <picmi-partial-workflow>`.
   - ``picongpu_add_custom_user_input()``:
     pass custom user input to the code generation.
     This may be used in conjunction with custom templates to change the code generation.

--- a/docs/source/usage/picmi/partial_workflow.rst
+++ b/docs/source/usage/picmi/partial_workflow.rst
@@ -122,6 +122,21 @@ Semantics
   a setup that has not been generated yet; changing them afterwards would
   invalidate the recorded state and is rejected with an error.
 
+.. note::
+
+   For the default local (``bash``) submit system the submitted job runs
+   ``<run_dir>/input/bin/picongpu`` from the run directory. The submit stage
+   pre-stages the ``bin/`` and ``etc/`` subdirectories there, but the rest
+   of the input (metadata, ``.build``, ``ro-crate.json``, ...) is only
+   copied into the run directory by the ``collect`` stage. A run that stops
+   after ``submit`` (e.g. ``picongpu_run(up_to=Stage.submit)``) therefore
+   leaves a *partial* ``input/`` directory: the local job can find its
+   binary, but it runs against the partial input, and the organized
+   artifacts (``tbg/``, the ``simOutput`` link, the submission information)
+   only appear in the run directory after ``collect``. Let the job finish
+   before running ``collect`` (or stage the remaining inputs by hand) if
+   the job needs the complete input directory.
+
 The workflow state file
 -----------------------
 

--- a/docs/source/usage/picmi/partial_workflow.rst
+++ b/docs/source/usage/picmi/partial_workflow.rst
@@ -106,12 +106,21 @@ The workflow state file
 -----------------------
 
 ``<run_dir>/.workflow_state.json`` records, for each stage, its status
-(``running``, ``completed``, ``failed``, ``invalidated``), a timestamp, and
-the locations of its artifacts (as CWL file objects). It is safe to delete:
-the next run then starts from scratch. Use
-``Runner.reset_workflow_state()`` for the same effect from Python.
+(``running``, ``completed``, ``failed``, ``invalidated``), a timestamp, a
+digest of the workflow inputs the stage was run with, and the locations of
+its artifacts (as CWL file objects). It is safe to delete: the next run then
+starts from scratch. Use ``Runner.reset_workflow_state()`` for the same
+effect from Python.
+
+The input digest is what detects edits to ``workflow/input.yaml`` between
+runs: a completed stage whose inputs changed is marked as stale (together
+with the stages that depend on it) and re-run, instead of being silently
+skipped with its stale artifacts.
 
 .. note::
 
    The state file complements, and does not replace, the cwltool job cache
-   (``<run_dir>/.cwl_cache``), which is kept as an internal optimization.
+   (``<run_dir>/.cwl_cache``), which the default single-invocation run uses
+   as an internal optimization. Per-step (stage-range) runs do not consult
+   the job cache: the stage state is their skip mechanism, and every
+   invoked step executes freshly.

--- a/docs/source/usage/picmi/partial_workflow.rst
+++ b/docs/source/usage/picmi/partial_workflow.rst
@@ -68,18 +68,38 @@ Resuming after a failure
 
 The progress of a run is persisted in ``<run_dir>/.workflow_state.json``.
 Stages that finished successfully are recorded there (keyed by stage name,
-never by workflow step name), together with the locations of their artifacts.
-When ``picongpu_run()`` is called again, completed stages are skipped and the
-run continues with the first incomplete stage — a run that failed (or was
-stopped) can be resumed without redoing the successful stages:
+never by workflow step name), together with the locations of their
+artifacts. When ``picongpu_run()`` is called again, completed stages are
+skipped and the run continues with the first incomplete stage.
+
+Stage-level resume applies to runs started with an explicit stage range
+(``up_to``/``from_``): the stages are executed one at a time and each is
+recorded as soon as it finishes, so after a failure only the failed stage
+and the stages after it are re-run:
 
 .. code-block:: python
 
-   # first attempt: failed inside 'submit'
-   sim.picongpu_run()
+   # first attempt: failed inside 'submit' ('build' and 'prepare' succeeded)
+   sim.picongpu_run(up_to=Stage.submit)
 
    # after fixing the problem: only 'submit' and 'collect' are re-run
    sim.picongpu_run()
+
+A failed *default* run (no stage arguments) works differently: it executes
+the complete workflow in a single cwltool invocation and records the stage
+state only after the whole workflow has succeeded. A failed default run
+therefore leaves no stage state behind; calling ``picongpu_run()`` again
+resumes at *job* granularity through the cwltool job cache: jobs whose
+inputs are byte-identical to the first attempt are skipped, and any changed
+input re-runs the workflow from that point on. (Recording per-stage progress
+during the single-invocation default run would change the historical
+"default = one workflow invocation" behavior and is a possible improvement
+for a later iteration.)
+
+Changed inputs are detected: each stage records a digest of the workflow
+inputs it was run with (see below), so an edit of ``workflow/input.yaml``
+after a completed run re-runs the affected stages (and the stages that
+depend on them) instead of silently skipping them.
 
 Semantics
 ---------

--- a/docs/source/usage/picmi/partial_workflow.rst
+++ b/docs/source/usage/picmi/partial_workflow.rst
@@ -1,0 +1,117 @@
+.. _picmi-partial-workflow:
+
+Partial Workflow Execution (Stages)
+===================================
+
+.. note::
+
+   This feature is a **draft** that was developed as an exploratory feature
+   request. The stage names and the argument names of
+   ``picongpu_run()`` are considered stable, but the overall interface may
+   still change before it is declared final.
+
+Running a PIConGPU simulation with the Python package drives a small
+`CWL <https://www.commonwl.org/>`_ workflow (``workflow.cwl``) that performs
+several actions in a row. These actions are exposed to users as **stages** —
+coarse-grained, stable milestones of a simulation run:
+
+=========  =====================================================
+Stage      What it does
+=========  =====================================================
+``build``  compiles the PIConGPU executable (``pic-build``)
+``prepare`` prepares the submission (``tbg``)
+``submit`` launches the simulation job on the batch system
+``collect`` organizes the results into the run directory
+=========  =====================================================
+
+Stages are intentionally decoupled from the individual CWL steps of the
+workflow: the number and the names of the workflow steps may change over time
+(e.g. when remote execution steps are added), while the stage names and their
+meaning stay stable. A stage may be implemented by one or several workflow
+steps; that mapping lives entirely inside the Python package.
+
+Selecting a subset of the workflow
+----------------------------------
+
+``Simulation.picongpu_run()`` accepts three additional keyword arguments to
+select which stages are executed:
+
+.. code-block:: python
+
+   from picongpu.picmi import Simulation, Stage
+
+   sim = Simulation(...)
+
+   # the default: run the whole pipeline, exactly as before
+   sim.picongpu_run()
+
+   # run everything up to and including the given stage
+   sim.picongpu_run(up_to=Stage.build)
+
+   # start with the given stage; earlier stages must already be completed
+   sim.picongpu_run(from_=Stage.submit)
+
+   # combine both to run exactly one stage
+   sim.picongpu_run(from_=Stage.submit, up_to=Stage.submit)
+
+   # re-run completed stages
+   sim.picongpu_run(force=True)                 # the whole pipeline
+   sim.picongpu_run(force=Stage.build)          # build and everything
+                                                # that depends on it
+
+The stages are executed in the order ``build``, ``prepare``, ``submit``,
+``collect``. ``from_`` and ``up_to`` both accept a :class:`~picongpu.picmi.Stage`
+or its string value (e.g. ``"build"``).
+
+Resuming after a failure
+------------------------
+
+The progress of a run is persisted in ``<run_dir>/.workflow_state.json``.
+Stages that finished successfully are recorded there (keyed by stage name,
+never by workflow step name), together with the locations of their artifacts.
+When ``picongpu_run()`` is called again, completed stages are skipped and the
+run continues with the first incomplete stage — a run that failed (or was
+stopped) can be resumed without redoing the successful stages:
+
+.. code-block:: python
+
+   # first attempt: failed inside 'submit'
+   sim.picongpu_run()
+
+   # after fixing the problem: only 'submit' and 'collect' are re-run
+   sim.picongpu_run()
+
+Semantics
+---------
+
+- **Missing prerequisites are an error.** Starting at a stage whose
+  prerequisites are not completed raises a ``WorkflowPrerequisiteError``
+  instead of silently running the missing stages. This is deliberate:
+  implicit execution could start work (e.g. compile a full binary) that the
+  user did not ask for.
+- **``force`` invalidates dependents.** Forcing a stage re-runs it and marks
+  all stages that depend on it as stale, so they are re-run as well
+  (e.g. ``force=Stage.build`` also re-runs ``submit`` and ``collect``, because
+  their inputs depend on the new binaries).
+- **The default behavior is unchanged.** ``picongpu_run()`` without stage
+  arguments runs the complete workflow in a single invocation, exactly as
+  before; stage-based execution only kicks in for explicit ranges and for
+  resuming partially completed runs.
+- **Workflow flags cannot be changed after generation.** ``picongpu_run()``
+  accepts the usual generation flags (``jobs``, ``cmake``, ...), but only for
+  a setup that has not been generated yet; changing them afterwards would
+  invalidate the recorded state and is rejected with an error.
+
+The workflow state file
+-----------------------
+
+``<run_dir>/.workflow_state.json`` records, for each stage, its status
+(``running``, ``completed``, ``failed``, ``invalidated``), a timestamp, and
+the locations of its artifacts (as CWL file objects). It is safe to delete:
+the next run then starts from scratch. Use
+``Runner.reset_workflow_state()`` for the same effect from Python.
+
+.. note::
+
+   The state file complements, and does not replace, the cwltool job cache
+   (``<run_dir>/.cwl_cache``), which is kept as an internal optimization.

--- a/docs/source/usage/picmi/partial_workflow.rst
+++ b/docs/source/usage/picmi/partial_workflow.rst
@@ -12,7 +12,7 @@ Partial Workflow Execution (Stages)
 
 Running a PIConGPU simulation with the Python package drives a small
 `CWL <https://www.commonwl.org/>`_ workflow (``workflow.cwl``) that performs
-several actions in a row. These actions are exposed to users as **stages** —
+several actions in a row. These actions are exposed to users as **stages** -
 coarse-grained, stable milestones of a simulation run:
 
 =========  =====================================================

--- a/lib/python/picongpu/picmi/__init__.py
+++ b/lib/python/picongpu/picmi/__init__.py
@@ -6,6 +6,8 @@ import sys
 
 import picmistandard
 
+from picongpu.pypicongpu import Stage
+
 from . import constants, diagnostics
 from .distribution import (
     AnalyticDistribution,
@@ -47,6 +49,7 @@ assert sys.version_info.major > 3 or sys.version_info.minor >= 11, "Python 3.11 
 
 __all__ = [
     "Simulation",
+    "Stage",
     "ParticleFunctor",
     "Cartesian3DGrid",
     "ElectromagneticSolver",

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -471,9 +471,11 @@ class Simulation(picmistandard.PICMI_Simulation):
           stages even if they are recorded as completed; stages that depend
           on them are invalidated as well
 
-        Progress is stored in ``<run_dir>/.workflow_state.json``, so a run
-        that failed or was stopped can be resumed without redoing the
-        successful stages.
+        Progress is stored in ``<run_dir>/.workflow_state.json``: a run
+        started with an explicit stage range that failed or was stopped can
+        be resumed without redoing the successful stages; a failed default
+        (no-argument) run leaves no stage state and resumes at job
+        granularity via the cwltool job cache (byte-identical inputs only).
         """
         runner = self.picongpu_get_runner(setup_dir=setup_dir, run_dir=run_dir)
         if not runner.workflow_input_path.exists():

--- a/lib/python/picongpu/picmi/simulation.py
+++ b/lib/python/picongpu/picmi/simulation.py
@@ -315,6 +315,15 @@ class Simulation(picmistandard.PICMI_Simulation):
 
     # @todo add refactor once restarts are supported by the Runner, Brian Marre, 2024
     def step(self, nsteps: int = 1, **flags):
+        """
+        Run the simulation for ``nsteps`` time steps.
+
+        PIConGPU runs the whole workflow for the full number of time steps in
+        one go, so ``nsteps`` must equal ``max_steps``. Note that this is
+        about time stepping, not about the workflow: selecting a subset of
+        the *workflow stages* (build/prepare/submit/collect) is done via
+        ``picongpu_run(up_to=..., from_=..., force=...)`` instead.
+        """
         if nsteps != self.max_steps:
             raise ValueError(
                 "PIConGPU does not support stepwise running. Invoke step() with max_steps (={})".format(self.max_steps)
@@ -445,11 +454,36 @@ class Simulation(picmistandard.PICMI_Simulation):
     def run(self, *args, **kwargs) -> None:
         return self.picongpu_run(*args, **kwargs)
 
-    def picongpu_run(self, setup_dir=None, run_dir=None, **flags) -> None:
-        """build and run PIConGPU simulation"""
+    def picongpu_run(self, setup_dir=None, run_dir=None, up_to=None, from_=None, force=None, **flags) -> None:
+        """
+        build and run PIConGPU simulation
+
+        By default the full pipeline (build, prepare, submit, collect) is
+        executed, as before. A subset of it can be selected with the stable
+        stage vocabulary (see ``picongpu.picmi.Stage``):
+
+        - ``up_to=Stage.build``: run all stages up to and including the given
+          stage
+        - ``from_=Stage.submit``: start with the given stage; earlier stages
+          must already be completed, otherwise a
+          ``WorkflowPrerequisiteError`` is raised
+        - ``force=True`` (or a stage / list of stages): re-run the given
+          stages even if they are recorded as completed; stages that depend
+          on them are invalidated as well
+
+        Progress is stored in ``<run_dir>/.workflow_state.json``, so a run
+        that failed or was stopped can be resumed without redoing the
+        successful stages.
+        """
         runner = self.picongpu_get_runner(setup_dir=setup_dir, run_dir=run_dir)
-        runner.generate(**flags)
-        runner.run()
+        if not runner.workflow_input_path.exists():
+            runner.generate(**flags)
+        elif flags:
+            raise ValueError(
+                "the setup was already generated, so workflow flags cannot be changed afterwards; "
+                "create a fresh setup (e.g. via write_input_file()) to run with different flags"
+            )
+        runner.run_range(up_to=up_to, from_=from_, force=force)
 
     def picongpu_get_runner(self, **kwargs) -> Runner:
         if self._runner is None:

--- a/lib/python/picongpu/pypicongpu/__init__.py
+++ b/lib/python/picongpu/pypicongpu/__init__.py
@@ -9,12 +9,22 @@ from .output.checkpoint import Checkpoint
 from .output.energy_histogram import EnergyHistogram
 from .output.macro_particle_count import MacroParticleCount
 from .output.phase_space import PhaseSpace
-from .runner import Runner
+from .runner import (
+    DEFAULT_STAGE_PLAN,
+    Runner,
+    Stage,
+    WorkflowPrerequisiteError,
+    WorkflowStageError,
+)
 from .simulation import Simulation
 
 __all__ = [
     "Simulation",
     "Runner",
+    "Stage",
+    "DEFAULT_STAGE_PLAN",
+    "WorkflowPrerequisiteError",
+    "WorkflowStageError",
     "laser",
     "output",
     "rendering",

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -7,6 +7,7 @@ License: GPLv3+
 
 import datetime
 import enum
+import hashlib
 import json
 import logging
 import shutil
@@ -370,6 +371,7 @@ class StageState(BaseModel):
     status: StageStatus
     updated_at: datetime.datetime | None = None
     artifacts: dict[str, dict[str, str]] = {}
+    inputs_digest: str | None = None
 
 
 class WorkflowState(BaseModel):
@@ -770,6 +772,28 @@ class Runner(BaseModel):
                     queue.append(dependent)
         return invalidated
 
+    def _stage_inputs_digest(self, stage: Stage) -> str:
+        """
+        SHA-256 digest of the workflow inputs consumed by a stage.
+
+        ``workflow/input.yaml`` is a plain file the user may edit at any time
+        (the ``build_``/``run_`` prefixed entries exist precisely to run the
+        steps individually), and nothing else on disk reflects such an edit.
+        Recording a digest per stage lets a re-run detect that the inputs of
+        a completed stage changed, instead of silently skipping it and
+        reusing stale artifacts.
+        """
+        spec = self.stage_plan[stage]
+        with self.workflow_input_path.open("r") as file:
+            workflow_inputs = json.load(file)
+        consumed = {
+            input_name: workflow_inputs[source]
+            for step_spec in spec.steps
+            for input_name, source in step_spec.inputs.items()
+            if isinstance(source, str) and source in workflow_inputs
+        }
+        return hashlib.sha256(json.dumps(consumed, sort_keys=True).encode()).hexdigest()
+
     def _record_full_run(self, state: WorkflowState, outputs: dict) -> None:
         """
         Record the stages as completed after a full single-invocation workflow run.
@@ -818,7 +842,12 @@ class Runner(BaseModel):
         for stage, stage_artifacts in artifacts.items():
             clean = {name: value for name, value in stage_artifacts.items() if value is not None}
             if clean:
-                state.stages[stage] = StageState(status=StageStatus.completed, updated_at=now, artifacts=clean)
+                state.stages[stage] = StageState(
+                    status=StageStatus.completed,
+                    updated_at=now,
+                    artifacts=clean,
+                    inputs_digest=self._stage_inputs_digest(stage),
+                )
         self._save_workflow_state(state)
 
     def _stage_outdir(self, stage: Stage, step_index: int) -> Path:
@@ -842,7 +871,13 @@ class Runner(BaseModel):
                             "outdir": str(outdir),
                             "rm_tmpdir": False,
                             "move_outputs": "copy",
-                            "cachedir": str(self.cwl_cachedir),
+                            # No job cache for per-step runs: the stage state (not the
+                            # job cache) decides what runs, and the job cache key does
+                            # not cover Directory contents -- a re-run stage that
+                            # regenerates an artifact directory in place would otherwise
+                            # serve its dependents stale cached outputs. The legacy
+                            # single-invocation full run (run()) keeps the shared cache.
+                            "cachedir": None,
                             "preserve_entire_environment": True,
                         }
                     )
@@ -888,6 +923,7 @@ class Runner(BaseModel):
         logging.info("running stage '%s' (steps: %s)", stage.value, [step.step for step in spec.steps])
         state.stages[stage] = StageState(status=StageStatus.running, updated_at=datetime.datetime.now())
         self._save_workflow_state(state)
+        inputs_digest = self._stage_inputs_digest(stage)
 
         try:
             step_outputs: dict[str, dict[str, dict[str, str]]] = {}
@@ -920,7 +956,10 @@ class Runner(BaseModel):
             raise
 
         state.stages[stage] = StageState(
-            status=StageStatus.completed, updated_at=datetime.datetime.now(), artifacts=stage_artifacts
+            status=StageStatus.completed,
+            updated_at=datetime.datetime.now(),
+            artifacts=stage_artifacts,
+            inputs_digest=inputs_digest,
         )
         self._save_workflow_state(state)
         return stage_artifacts
@@ -943,8 +982,12 @@ class Runner(BaseModel):
           stage are invalidated as well, so they are re-run too.
 
         Progress is persisted in ``run_dir/.workflow_state.json`` (keyed by
-        stage, never by CWL step). Returns the artifacts of the last executed
-        stage, or ``None`` if everything was already up to date.
+        stage, never by CWL step). A completed stage is skipped only if the
+        workflow inputs it consumed have not changed since it ran (each
+        stage records a digest of them); changed inputs invalidate the
+        affected stages and the stages that depend on them. Returns the
+        artifacts of the last executed stage, or ``None`` if everything was
+        already up to date.
         """
         plan = self.stage_plan
         up_to = Stage(up_to) if up_to is not None else None
@@ -960,6 +1003,28 @@ class Runner(BaseModel):
 
         state = self._load_workflow_state()
 
+        # Detect changes to workflow/input.yaml since the stages were last
+        # executed: a completed stage whose recorded input digest no longer
+        # matches (or which has none at all, e.g. a state file from before
+        # digest recording) is stale, and so are the stages that depend on it.
+        stale = set()
+        if self.workflow_input_path.is_file():
+            for stage, entry in state.stages.items():
+                if entry.status is not StageStatus.completed:
+                    continue
+                if entry.inputs_digest is None:
+                    logging.warning(
+                        "stage '%s' was recorded without an input digest; treating it as stale", stage.value
+                    )
+                    stale.add(stage)
+                elif entry.inputs_digest != self._stage_inputs_digest(stage):
+                    logging.warning(
+                        "the workflow inputs of stage '%s' changed since it was last executed; "
+                        "it and the stages that depend on it will be re-run",
+                        stage.value,
+                    )
+                    stale.add(stage)
+
         if up_to is None and from_ is None and not forced and not state.completed:
             # Historical full-run path: single cwltool invocation of workflow.cwl
             outputs = self.run()
@@ -970,15 +1035,17 @@ class Runner(BaseModel):
         high = order.index(up_to) if up_to is not None else len(order) - 1
         range_stages = order[low : high + 1]
 
-        invalidated = self._invalidated_dependents(forced, plan)
+        invalidated = self._invalidated_dependents(forced, plan) | self._invalidated_dependents(stale, plan)
         for stage in invalidated:
-            if state.stages.get(stage) is not None and state.stages[stage].status is StageStatus.completed:
+            entry = state.stages.get(stage)
+            if entry is not None and entry.status is StageStatus.completed:
                 state.stages[stage] = StageState(
                     status=StageStatus.invalidated,
                     updated_at=datetime.datetime.now(),
-                    artifacts=state.stages[stage].artifacts,
+                    artifacts=entry.artifacts,
+                    inputs_digest=entry.inputs_digest,
                 )
-        if forced:
+        if invalidated:
             self._save_workflow_state(state)
 
         completed = state.completed - invalidated

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -312,7 +312,6 @@ DEFAULT_STAGE_PLAN = StagePlan(
                         "etc_directory": "run_etc_directory",
                         "tbg_link": StageArtifactRef(stage=Stage.prepare, artifact="tbg_directory"),
                         "submit_system": "run_submit_system",
-                        "destination_path": "destination_path",
                     },
                     outputs={
                         "submission_information": "submission_information",

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -886,6 +886,11 @@ class Runner(BaseModel):
             )
         except WorkflowStatus as error:
             raise WorkflowStageError(f"running CWL step {step_path.name} failed: {error}") from error
+        except Exception as error:
+            # cwltool load/validation failures (e.g. a renamed or missing step
+            # file) surface here; wrap them so stage execution has a single
+            # documented error type
+            raise WorkflowStageError(f"loading/running CWL step {step_path} failed: {error}") from error
 
     def _resolve_step_inputs(self, step_spec: StageStepSpec, state: WorkflowState, step_outputs: dict) -> dict:
         with self.workflow_input_path.open("r") as file:

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -6,9 +6,12 @@ License: GPLv3+
 """
 
 import datetime
+import enum
 import json
 import logging
+import shutil
 import tempfile
+import urllib.parse
 from importlib.util import module_from_spec, spec_from_file_location
 from os import chmod
 from pathlib import Path
@@ -17,6 +20,7 @@ from typing import Annotated, Sequence
 
 from cwltool.context import RuntimeContext
 from cwltool.factory import Factory as WorkflowFactory
+from cwltool.factory import WorkflowStatus
 from pydantic import (
     AfterValidator,
     AliasChoices,
@@ -167,6 +171,239 @@ class TBGFlags(BaseModel):
         return {"class": "Directory", "location": str(value)}
 
 
+class Stage(str, enum.Enum):
+    """
+    Stable, user-facing execution stages of the PIConGPU workflow.
+
+    Stages are the milestones of a simulation run. They are deliberately
+    coarse-grained and decoupled from the individual CWL steps of
+    ``workflow.cwl`` (whose number and names may change over time, e.g. when
+    remote-execution steps are added). A stage may be implemented by one or
+    several CWL steps; the mapping lives in a :class:`StagePlan` inside the
+    runner, and both the public API and the persisted workflow state speak
+    only in stages, never in CWL step names.
+
+    The stages in execution order are:
+
+    - ``build``: compile the simulation executable (pic-build)
+    - ``prepare``: prepare the submission (tbg)
+    - ``submit``: launch the simulation job on the batch system
+    - ``collect``: organize the results into the run directory
+    """
+
+    build = "build"
+    prepare = "prepare"
+    submit = "submit"
+    collect = "collect"
+
+
+class StageArtifactRef(BaseModel):
+    """Reference to an artifact produced by an earlier, completed stage."""
+
+    stage: Stage
+    artifact: str
+
+
+class StepOutputRef(BaseModel):
+    """Reference to an output of a preceding step within the same stage."""
+
+    step: str
+    output: str
+
+
+class StageStepSpec(BaseModel):
+    """
+    How to run one CWL step of the workflow as part of a stage.
+
+    ``inputs`` maps the step's input parameters to their source: a bare
+    string names a workflow input (from ``workflow/input.yaml``), a
+    :class:`StageArtifactRef` takes the value from a completed stage's
+    recorded artifact, and a :class:`StepOutputRef` wires an output of a
+    preceding step of the same stage.
+
+    ``outputs`` maps stage artifact names to the step's output parameters;
+    the resulting artifact locations are recorded in the workflow state.
+    """
+
+    step: str
+    run: str
+    inputs: dict[str, str | StageArtifactRef | StepOutputRef]
+    outputs: dict[str, str] = {}
+
+
+class StageSpec(BaseModel):
+    """A stage: the stages it depends on and the CWL steps that implement it."""
+
+    name: Stage
+    depends_on: tuple[Stage, ...] = ()
+    steps: list[StageStepSpec]
+
+
+class StagePlan(BaseModel):
+    """
+    The stage -> CWL step adapter.
+
+    This is the single place in the code base that knows the current layout
+    of ``workflow.cwl``. ``order`` is the execution (topological) order of
+    the stages; ``stages`` maps each stage to its spec.
+    """
+
+    order: tuple[Stage, ...]
+    stages: dict[Stage, StageSpec]
+
+    def __getitem__(self, stage: Stage | str) -> StageSpec:
+        return self.stages[Stage(stage)]
+
+
+# The current mapping of the stable stages onto the CWL steps of
+# workflow.cwl. If steps are added, removed, or reorganised, only this
+# mapping (and the workflow templates) need to change, not the public API.
+DEFAULT_STAGE_PLAN = StagePlan(
+    order=(Stage.build, Stage.prepare, Stage.submit, Stage.collect),
+    stages={
+        Stage.build: StageSpec(
+            name=Stage.build,
+            steps=[
+                StageStepSpec(
+                    step="build_step",
+                    run="steps/build.cwl",
+                    inputs={
+                        "include_directory": "build_include_directory",
+                        "script": "build_script",
+                        "jobs": "build_jobs",
+                        "cmake": "build_cmake",
+                        "preset": "build_preset",
+                        "force": "build_force",
+                        "cmake_build_system": "build_cmake_build_system",
+                    },
+                    outputs={"bin_directory": "bin_directory"},
+                )
+            ],
+        ),
+        Stage.prepare: StageSpec(
+            name=Stage.prepare,
+            steps=[
+                StageStepSpec(
+                    step="prepare_submission_step",
+                    run="steps/prepare_submission.cwl",
+                    inputs={
+                        "etc_directory": "run_etc_directory",
+                        "script": "prepare_submission_script",
+                        "cfg_file": "run_cfg_file",
+                        "overwrite_vars": "run_overwrite_vars",
+                        "template_file": "run_template_file",
+                        "force": "run_force",
+                    },
+                    outputs={"tbg_directory": "tbg_directory"},
+                )
+            ],
+        ),
+        Stage.submit: StageSpec(
+            name=Stage.submit,
+            depends_on=(Stage.build, Stage.prepare),
+            steps=[
+                StageStepSpec(
+                    step="submit_step",
+                    run="steps/submit.cwl",
+                    inputs={
+                        "script": "submission_script",
+                        "bin_directory": StageArtifactRef(stage=Stage.build, artifact="bin_directory"),
+                        "etc_directory": "run_etc_directory",
+                        "tbg_link": StageArtifactRef(stage=Stage.prepare, artifact="tbg_directory"),
+                        "submit_system": "run_submit_system",
+                        "destination_path": "destination_path",
+                    },
+                    outputs={
+                        "submission_information": "submission_information",
+                        "link_results_script": "link_results_script",
+                        "tbg_directory": "tbg_directory",
+                    },
+                )
+            ],
+        ),
+        Stage.collect: StageSpec(
+            name=Stage.collect,
+            depends_on=(Stage.build, Stage.submit),
+            steps=[
+                StageStepSpec(
+                    step="organize_output_step",
+                    run="steps/organize_output.cwl",
+                    inputs={
+                        "script": "organize_output_script",
+                        "project_path": "run_project_path",
+                        "bin_directory": StageArtifactRef(stage=Stage.build, artifact="bin_directory"),
+                        "tbg_directory": StageArtifactRef(stage=Stage.submit, artifact="tbg_directory"),
+                        "submission_information": StageArtifactRef(
+                            stage=Stage.submit, artifact="submission_information"
+                        ),
+                        "link_results_script": StageArtifactRef(stage=Stage.submit, artifact="link_results_script"),
+                    },
+                    outputs={
+                        "input_directory": "input_directory",
+                        "tbg_directory": "tbg_directory",
+                        "submission_information": "submission_information",
+                        "link_results_script": "link_results_script",
+                    },
+                )
+            ],
+        ),
+    },
+)
+
+
+class WorkflowStageError(RuntimeError):
+    """A stage failed to execute."""
+
+
+class WorkflowPrerequisiteError(RuntimeError):
+    """A stage was requested whose prerequisites are not completed."""
+
+
+class StageStatus(str, enum.Enum):
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+    invalidated = "invalidated"
+
+
+class StageState(BaseModel):
+    status: StageStatus
+    updated_at: datetime.datetime | None = None
+    artifacts: dict[str, dict[str, str]] = {}
+
+
+class WorkflowState(BaseModel):
+    """
+    Persisted, stage-keyed state of the workflow, stored in
+    ``run_dir/.workflow_state.json``.
+
+    Only stage names ever appear in this file (never CWL step names), so
+    reorganising the workflow steps does not invalidate the state.
+    Artifacts are stored as reduced CWL file objects (``class`` +
+    ``location``) so they can be re-staged as inputs of later steps.
+    """
+
+    version: int = 1
+    updated_at: datetime.datetime | None = None
+    stages: dict[Stage, StageState] = {}
+
+    @property
+    def completed(self) -> set[Stage]:
+        return {stage for stage, entry in self.stages.items() if entry.status is StageStatus.completed}
+
+
+def cwl_location_to_path(location: str) -> Path:
+    """Convert a cwltool file location (file:// URI or plain path) to a local path."""
+    if location.startswith("file://"):
+        return Path(urllib.parse.unquote(urllib.parse.urlparse(location).path))
+    return Path(location)
+
+
+def reduce_cwl_file(file: dict) -> dict[str, str]:
+    """Keep only what is needed to re-stage a cwltool File/Directory output as an input."""
+    return {"class": file["class"], "location": str(cwl_location_to_path(file["location"]))}
+
+
 class Runner(BaseModel):
     """
     Accepts a PyPIConGPU Simulation and runs it
@@ -215,6 +452,7 @@ class Runner(BaseModel):
         default_factory=lambda: Path(get_tmpdir_with_name("run")).absolute()
     )
     sim: Annotated[Simulation, BeforeValidator(lambda s: alt(lambda: s.get_as_pypicongpu(), s))]
+    stage_plan: StagePlan = Field(default_factory=lambda: DEFAULT_STAGE_PLAN)
 
     def _log_dirs(self):
         """print human-readble list of paths to log"""
@@ -295,6 +533,10 @@ class Runner(BaseModel):
     @property
     def cwl_cachedir(self):
         return self.run_dir / ".cwl_cache"
+
+    @property
+    def workflow_state_path(self):
+        return self.run_dir / ".workflow_state.json"
 
     def generate_profile(self):
         self.profile_path.parent.mkdir(parents=True, exist_ok=True)
@@ -469,3 +711,291 @@ class Runner(BaseModel):
                     }
                 )
             ).make(str(self.workflow_definition_path))(**json.load(file))
+
+    # ------------------------------------------------------------------
+    # Partial execution: stages, state, and stage ranges
+    # ------------------------------------------------------------------
+
+    def _load_workflow_state(self) -> WorkflowState:
+        if not self.workflow_state_path.is_file():
+            return WorkflowState()
+        try:
+            with self.workflow_state_path.open("r") as file:
+                return WorkflowState.model_validate(json.load(file))
+        except (OSError, ValueError) as error:
+            logging.warning(
+                "could not read workflow state %s: %s; starting with an empty state", self.workflow_state_path, error
+            )
+            return WorkflowState()
+
+    def _save_workflow_state(self, state: WorkflowState):
+        state.updated_at = datetime.datetime.now()
+        tmp_path = self.workflow_state_path.with_suffix(".json.tmp")
+        with tmp_path.open("w") as file:
+            json.dump(state.model_dump(mode="json"), file, indent=4)
+        tmp_path.replace(self.workflow_state_path)
+
+    def reset_workflow_state(self) -> None:
+        """Forget all recorded stage progress (e.g. because the inputs changed)."""
+        self.workflow_state_path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _resolve_force(force, plan: StagePlan) -> set[Stage]:
+        if not force:
+            return set()
+        if force is True:
+            return set(plan.order)
+        stages = [Stage(stage) for stage in force] if isinstance(force, (list, tuple)) else [Stage(force)]
+        known = {stage.value for stage in plan.order}
+        unknown = sorted({stage.value for stage in stages} - known)
+        if unknown:
+            raise ValueError(
+                f"unknown stage(s) {unknown}; known stages in execution order: {[s.value for s in plan.order]}"
+            )
+        return set(stages)
+
+    @staticmethod
+    def _invalidated_dependents(forced: set[Stage], plan: StagePlan) -> set[Stage]:
+        """A forced stage invalidates itself and everything that depends on it."""
+        dependents: dict[Stage, set[Stage]] = {stage: set() for stage in plan.order}
+        for stage in plan.order:
+            for dependency in plan[stage].depends_on:
+                dependents[dependency].add(stage)
+        invalidated = set(forced)
+        queue = list(forced)
+        while queue:
+            for dependent in dependents[queue.pop()]:
+                if dependent not in invalidated:
+                    invalidated.add(dependent)
+                    queue.append(dependent)
+        return invalidated
+
+    def _record_full_run(self, state: WorkflowState, outputs: dict) -> None:
+        """
+        Record the stages as completed after a full single-invocation workflow run.
+
+        The workflow's final outputs are the stable, organized artifacts in the
+        run directory. The intermediate stages' outputs are only reachable
+        through them (e.g. the built binaries are part of the organized input
+        directory, cf. organize_output.sh), so they are recorded with the
+        stable locations they have there.
+        """
+
+        def reduced(parameter: str) -> dict[str, str] | None:
+            value = outputs.get(parameter)
+            if isinstance(value, dict) and "location" in value and value.get("class") in ("File", "Directory"):
+                return reduce_cwl_file(value)
+            return None
+
+        input_directory = reduced("input_directory")
+        tbg_directory = reduced("tbg_directory")
+        submission_information = reduced("submission_information")
+        link_results_script = reduced("link_results_script")
+
+        artifacts = {
+            Stage.collect: {
+                "input_directory": input_directory,
+                "tbg_directory": tbg_directory,
+                "submission_information": submission_information,
+                "link_results_script": link_results_script,
+            },
+            Stage.submit: {
+                "tbg_directory": tbg_directory,
+                "submission_information": submission_information,
+                "link_results_script": link_results_script,
+            },
+            Stage.prepare: {"tbg_directory": tbg_directory},
+            Stage.build: {"bin_directory": None},
+        }
+        if input_directory is not None:
+            # organize_output.sh copies the built binaries into input/bin
+            artifacts[Stage.build]["bin_directory"] = {
+                "class": "Directory",
+                "location": str(Path(input_directory["location"]) / "bin"),
+            }
+
+        now = datetime.datetime.now()
+        for stage, stage_artifacts in artifacts.items():
+            clean = {name: value for name, value in stage_artifacts.items() if value is not None}
+            if clean:
+                state.stages[stage] = StageState(status=StageStatus.completed, updated_at=now, artifacts=clean)
+        self._save_workflow_state(state)
+
+    def _stage_outdir(self, stage: Stage, step_index: int) -> Path:
+        # The final stage's last step writes its outputs directly into the run
+        # directory, exactly where the full workflow places them. The other
+        # steps write to private, numbered subdirectories (no CWL step names,
+        # so the on-disk layout survives step reorganisation, like the state).
+        spec = self.stage_plan[stage]
+        if stage is self.stage_plan.order[-1] and step_index == len(spec.steps) - 1:
+            return self.run_dir
+        return self.run_dir / ".stage_outputs" / stage.value / f"step-{step_index + 1}"
+
+    def _run_cwl_step(self, step_path: Path, inputs: dict, outdir: Path) -> dict:
+        outdir.mkdir(parents=True, exist_ok=True)
+        self.cwl_cachedir.mkdir(parents=True, exist_ok=True)
+        try:
+            return (
+                WorkflowFactory(
+                    runtime_context=RuntimeContext(
+                        kwargs={
+                            "outdir": str(outdir),
+                            "rm_tmpdir": False,
+                            "move_outputs": "copy",
+                            "cachedir": str(self.cwl_cachedir),
+                            "preserve_entire_environment": True,
+                        }
+                    )
+                ).make(str(step_path))(**inputs)
+                or {}
+            )
+        except WorkflowStatus as error:
+            raise WorkflowStageError(f"running CWL step {step_path.name} failed: {error}") from error
+
+    def _resolve_step_inputs(self, step_spec: StageStepSpec, state: WorkflowState, step_outputs: dict) -> dict:
+        with self.workflow_input_path.open("r") as file:
+            workflow_inputs = json.load(file)
+        inputs = {}
+        for input_name, source in step_spec.inputs.items():
+            if isinstance(source, str):
+                if source not in workflow_inputs:
+                    raise WorkflowStageError(
+                        f"workflow input '{source}' for step '{step_spec.step}' is missing from {self.workflow_input_path}"
+                    )
+                inputs[input_name] = workflow_inputs[source]
+            elif isinstance(source, StageArtifactRef):
+                stage_state = state.stages.get(source.stage)
+                artifact = stage_state.artifacts.get(source.artifact) if stage_state is not None else None
+                if artifact is None:
+                    raise WorkflowStageError(
+                        f"cannot run step '{step_spec.step}': artifact '{source.artifact}' of stage "
+                        f"'{source.stage.value}' is not available; run that stage first (or reset "
+                        f"{self.workflow_state_path})"
+                    )
+                inputs[input_name] = artifact
+            elif isinstance(source, StepOutputRef):
+                artifact = step_outputs.get(source.step, {}).get(source.output)
+                if artifact is None:
+                    raise WorkflowStageError(
+                        f"step '{step_spec.step}' references output '{source.output}' of step '{source.step}', "
+                        f"which is not part of the same stage"
+                    )
+                inputs[input_name] = artifact
+        return inputs
+
+    def _run_stage(self, stage: Stage, state: WorkflowState) -> dict:
+        spec = self.stage_plan[stage]
+        logging.info("running stage '%s' (steps: %s)", stage.value, [step.step for step in spec.steps])
+        state.stages[stage] = StageState(status=StageStatus.running, updated_at=datetime.datetime.now())
+        self._save_workflow_state(state)
+
+        try:
+            step_outputs: dict[str, dict[str, dict[str, str]]] = {}
+            stage_artifacts: dict[str, dict[str, str]] = {}
+            for step_index, step_spec in enumerate(spec.steps):
+                outdir = self._stage_outdir(stage, step_index)
+                # Private per-step output directory: start clean. Never touch
+                # the run directory itself.
+                if outdir != self.run_dir and outdir.exists():
+                    shutil.rmtree(outdir)
+                inputs = self._resolve_step_inputs(step_spec, state, step_outputs)
+                outputs = self._run_cwl_step(self.workflow_dir_path / step_spec.run, inputs, outdir)
+                for output_name, output in outputs.items():
+                    if (
+                        isinstance(output, dict)
+                        and "location" in output
+                        and output.get("class") in ("File", "Directory")
+                    ):
+                        step_outputs.setdefault(step_spec.step, {})[output_name] = reduce_cwl_file(output)
+                for artifact_name, output_name in step_spec.outputs.items():
+                    if output_name not in step_outputs.get(step_spec.step, {}):
+                        raise WorkflowStageError(
+                            f"step '{step_spec.step}' did not produce output '{output_name}' "
+                            f"required for artifact '{artifact_name}'"
+                        )
+                    stage_artifacts[artifact_name] = step_outputs[step_spec.step][output_name]
+        except Exception:
+            state.stages[stage] = StageState(status=StageStatus.failed, updated_at=datetime.datetime.now())
+            self._save_workflow_state(state)
+            raise
+
+        state.stages[stage] = StageState(
+            status=StageStatus.completed, updated_at=datetime.datetime.now(), artifacts=stage_artifacts
+        )
+        self._save_workflow_state(state)
+        return stage_artifacts
+
+    def run_range(self, up_to: Stage | str | None = None, from_: Stage | str | None = None, force=None):
+        """
+        Execute the stages in the range ``[from_, up_to]`` of the workflow.
+
+        - no arguments: the full pipeline. If no stage is recorded as
+          completed, the complete ``workflow.cwl`` is run in a single
+          cwltool invocation (the historical behavior). If earlier partial
+          runs completed some stages, the remaining stages are executed
+          individually and the completed ones are skipped.
+        - ``up_to``: run all stages up to and including this one.
+        - ``from_``: start with this stage; earlier stages must already be
+          completed, otherwise a :class:`WorkflowPrerequisiteError` is
+          raised (running the missing prerequisites is not done implicitly).
+        - ``force``: ``True`` re-runs every stage of the range; a stage or a
+          list of stages re-runs those stages. Stages that depend on a forced
+          stage are invalidated as well, so they are re-run too.
+
+        Progress is persisted in ``run_dir/.workflow_state.json`` (keyed by
+        stage, never by CWL step). Returns the artifacts of the last executed
+        stage, or ``None`` if everything was already up to date.
+        """
+        plan = self.stage_plan
+        up_to = Stage(up_to) if up_to is not None else None
+        from_ = Stage(from_) if from_ is not None else None
+        forced = self._resolve_force(force, plan)
+
+        order = list(plan.order)
+        if up_to is not None and from_ is not None and order.index(from_) > order.index(up_to):
+            raise ValueError(
+                f"from_ ({from_.value}) is after up_to ({up_to.value}) in the pipeline order "
+                f"({', '.join(stage.value for stage in order)})"
+            )
+
+        state = self._load_workflow_state()
+
+        if up_to is None and from_ is None and not forced and not state.completed:
+            # Historical full-run path: single cwltool invocation of workflow.cwl
+            outputs = self.run()
+            self._record_full_run(state, outputs)
+            return outputs
+
+        low = order.index(from_) if from_ is not None else 0
+        high = order.index(up_to) if up_to is not None else len(order) - 1
+        range_stages = order[low : high + 1]
+
+        invalidated = self._invalidated_dependents(forced, plan)
+        for stage in invalidated:
+            if state.stages.get(stage) is not None and state.stages[stage].status is StageStatus.completed:
+                state.stages[stage] = StageState(
+                    status=StageStatus.invalidated,
+                    updated_at=datetime.datetime.now(),
+                    artifacts=state.stages[stage].artifacts,
+                )
+        if forced:
+            self._save_workflow_state(state)
+
+        completed = state.completed - invalidated
+        for stage in range_stages:
+            missing = [dep for dep in plan[stage].depends_on if dep not in range_stages and dep not in completed]
+            if missing:
+                raise WorkflowPrerequisiteError(
+                    "cannot run stage '{}' without completed prerequisite(s) {}; run them first "
+                    "(e.g. picongpu_run(up_to=...)) or invoke the full pipeline without a range".format(
+                        stage.value, ", ".join(dep.value for dep in missing)
+                    )
+                )
+
+        last_artifacts = None
+        for stage in range_stages:
+            if stage in completed:
+                logging.info("stage '%s' already completed, skipping", stage.value)
+                continue
+            last_artifacts = self._run_stage(stage, state)
+        return last_artifacts

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -1003,8 +1003,9 @@ class Runner(BaseModel):
         workflow inputs it consumed have not changed since it ran (each
         stage records a digest of them); changed inputs invalidate the
         affected stages and the stages that depend on them. Returns the
-        artifacts of the last executed stage, or ``None`` if everything was
-        already up to date.
+        artifacts of the last executed stage (for the legacy single-invocation
+        full run, the artifacts recorded for the final stage), or ``None`` if
+        everything was already up to date.
         """
         plan = self.stage_plan
         up_to = Stage(up_to) if up_to is not None else None
@@ -1046,7 +1047,10 @@ class Runner(BaseModel):
             # Historical full-run path: single cwltool invocation of workflow.cwl
             outputs = self.run()
             self._record_full_run(state, outputs)
-            return outputs
+            # Same contract as the per-step path: the artifacts of the last
+            # executed stage, here the final stage of the plan.
+            last_stage = state.stages.get(plan.order[-1])
+            return last_stage.artifacts if last_stage is not None else None
 
         low = order.index(from_) if from_ is not None else 0
         high = order.index(up_to) if up_to is not None else len(order) - 1

--- a/lib/python/picongpu/pypicongpu/runner.py
+++ b/lib/python/picongpu/pypicongpu/runner.py
@@ -723,12 +723,24 @@ class Runner(BaseModel):
             return WorkflowState()
         try:
             with self.workflow_state_path.open("r") as file:
-                return WorkflowState.model_validate(json.load(file))
+                state = WorkflowState.model_validate(json.load(file))
         except (OSError, ValueError) as error:
             logging.warning(
                 "could not read workflow state %s: %s; starting with an empty state", self.workflow_state_path, error
             )
             return WorkflowState()
+        if state.version != 1:
+            # version 1 is the only format this runner writes and reads; an
+            # unknown version is ignored (treated as empty) rather than
+            # guessed at -- a future format change starts from a clean state
+            logging.warning(
+                "workflow state %s has version %s, but this runner only supports version 1; "
+                "the recorded progress is ignored",
+                self.workflow_state_path,
+                state.version,
+            )
+            return WorkflowState()
+        return state
 
     def _save_workflow_state(self, state: WorkflowState):
         state.updated_at = datetime.datetime.now()

--- a/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
+++ b/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
@@ -386,6 +386,23 @@ def test_step_file_renamed_raises_workflow_stage_error(runner):
         runner.run_range(up_to=Stage.build)
 
 
+def test_unknown_state_version_is_ignored(runner):
+    # a state file with an unknown version must not be trusted: it is
+    # treated as empty, the stage is re-run, and the state is re-recorded
+    # with the supported version (had the foreign state been trusted, the
+    # stage would have been skipped and the file would still say version 99)
+    runner.run_range(up_to=Stage.build)
+    state = json.loads(runner.workflow_state_path.read_text())
+    state["version"] = 99
+    runner.workflow_state_path.write_text(json.dumps(state))
+
+    runner.run_range(up_to=Stage.build)
+
+    state = json.loads(runner.workflow_state_path.read_text())
+    assert state["version"] == 1
+    assert state["stages"][Stage.build.value]["status"] == "completed"
+
+
 def test_force_stage_invalidates_dependents(runner):
     runner.run_range()
     state = load_state(runner)

--- a/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
+++ b/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
@@ -139,8 +139,6 @@ inputs:
     type: Directory
   submit_system:
     type: string?
-  destination_path:
-    type: string?
 outputs:
   submission_information:
     type: File
@@ -563,7 +561,6 @@ def future_stage_plan():
                 "etc_directory": "run_etc_directory",
                 "tbg_link": StepOutputRef(step="upload_step", output="uploaded"),
                 "submit_system": "run_submit_system",
-                "destination_path": "destination_path",
             },
             outputs={
                 "submission_information": "submission_information",

--- a/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
+++ b/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
@@ -9,6 +9,7 @@ import json
 import shutil
 from pathlib import Path
 
+import yaml
 from picongpu.picmi import Cartesian3DGrid, ElectromagneticSolver, Stage, Simulation
 from picongpu.pypicongpu.runner import (
     DEFAULT_STAGE_PLAN,
@@ -18,6 +19,7 @@ from picongpu.pypicongpu.runner import (
     WorkflowPrerequisiteError,
     WorkflowStageError,
 )
+from picongpu.templates import path as tpath
 from pytest import fixture, raises
 
 
@@ -476,6 +478,72 @@ def test_input_change_invalidates_completed_stages(runner):
     assert (run_dir / "tbg" / "bin_from_build").read_text() == "built-v2\n"
 
 
+def test_default_plan_matches_workflow_template():
+    # The stage plan is the single place that knows the current workflow.cwl
+    # layout, but the per-step path never reads workflow.cwl -- so drift
+    # (a renamed step file, a renamed input, an added step) would make full
+    # and partial runs silently diverge. This test pins the default plan to
+    # the real template.
+    workflow = yaml.safe_load((tpath() / "workflow" / "workflow.cwl").read_text())
+    workflow_steps = workflow["steps"]
+    workflow_inputs = set(workflow["inputs"])
+    all_plan_steps = [(stage, spec) for stage, s in DEFAULT_STAGE_PLAN.stages.items() for spec in s.steps]
+
+    def plan_step_of(run_file: str):
+        matches = [(stage, spec) for stage, spec in all_plan_steps if spec.run == run_file]
+        assert len(matches) == 1, f"exactly one plan step must run {run_file!r}, found {len(matches)}"
+        return matches[0]
+
+    for step_id, step in workflow_steps.items():
+        # every workflow step is covered by exactly one plan step (same file)
+        stage, spec = plan_step_of(step["run"])
+
+        # the plan step offers exactly the workflow step's inputs
+        assert set(spec.inputs) == set(step["in"]), (
+            f"plan step {spec.step!r} input names differ from workflow step {step_id!r}: "
+            f"{sorted(set(spec.inputs) ^ set(step['in']))}"
+        )
+        for input_name, source in spec.inputs.items():
+            workflow_source = step["in"][input_name]
+            if "/" not in str(workflow_source):
+                # sourced from a workflow input
+                assert source == workflow_source, (
+                    f"workflow step {step_id!r} input {input_name!r} comes from {workflow_source!r} "
+                    f"in the workflow but from {source!r} in the plan"
+                )
+                assert source in workflow_inputs, f"workflow input {source!r} is not defined in workflow.cwl"
+            else:
+                producer_id, output = str(workflow_source).split("/", 1)
+                producer_stage, producer_spec = plan_step_of(workflow_steps[producer_id]["run"])
+                assert output in producer_spec.outputs.values(), (
+                    f"workflow step {step_id!r} consumes {workflow_source!r}, but plan step "
+                    f"{producer_spec.step!r} records no such output"
+                )
+                if isinstance(source, StageArtifactRef):
+                    assert source.stage == producer_stage and source.artifact == output, (
+                        f"plan step {spec.step!r} input {input_name!r} is {source!r}, but the workflow "
+                        f"takes {workflow_source!r} (stage {producer_stage.value!r})"
+                    )
+                elif isinstance(source, StepOutputRef):
+                    assert producer_stage == stage and source.step == producer_id and source.output == output, (
+                        f"plan step {spec.step!r} input {input_name!r} is {source!r}, but the workflow "
+                        f"takes {workflow_source!r}"
+                    )
+                else:
+                    raise AssertionError(
+                        f"plan step {spec.step!r} input {input_name!r} is {source!r}, expected a "
+                        f"StageArtifactRef or StepOutputRef for the workflow source {workflow_source!r}"
+                    )
+        # every output of the workflow step is recorded by the plan step
+        missing = set(step["out"]) - set(spec.outputs.values())
+        assert not missing, (
+            f"workflow step {step_id!r} outputs {sorted(missing)} are not recorded by plan step {spec.step!r}"
+        )
+
+    # and the plan does not reference step files that are not workflow steps
+    assert {spec.run for _, spec in all_plan_steps} == {step["run"] for step in workflow_steps.values()}
+
+
 def future_stage_plan():
     """A "future" plan where the submit stage gained an extra (upload) step."""
     plan = DEFAULT_STAGE_PLAN.model_copy(deep=True)
@@ -507,10 +575,41 @@ def future_stage_plan():
     return plan
 
 
+def mutate_workflow_cwl(runner) -> str:
+    """
+    Simulate a "future" workflow.cwl in the generated setup: the build step
+    id is renamed and a new upload step is inserted ahead of the submit step.
+
+    The per-step path never reads workflow.cwl; the point is that the stage
+    API keeps working while the workflow file drifts (the plan is updated
+    accordingly, as a maintainer would do).
+    """
+    wf_path = runner.workflow_dir_path / "workflow.cwl"
+    text = wf_path.read_text()
+    text = text.replace("build_step", "compile_step")
+    text = text.replace(
+        "  submit_step:\n",
+        (
+            "  upload_step:\n"
+            "    run: steps/upload.cwl\n"
+            "    in:\n"
+            "      tbg_link: prepare_submission_step/tbg_directory\n"
+            "    out: [uploaded]\n"
+            "  submit_step:\n"
+        ),
+    )
+    wf_path.write_text(text)
+    return text
+
+
 def test_stability_future_workflow(runner):
-    # A future workflow with an extra step inserted inside the submit stage
-    # must keep the public API (stage names, ranges, state file) unchanged.
+    # A future workflow (a mutated scratch workflow.cwl: a renamed step id
+    # and a step inserted inside the submit stage) with a correspondingly
+    # updated plan must keep the public API (stage names, ranges, state
+    # file) unchanged.
     install_dummy_workflow(runner, extra_steps={"upload.cwl": ECHO_UPLOAD_CWL})
+    text = mutate_workflow_cwl(runner)
+    assert "compile_step" in text and "upload_step" in text, "the scratch workflow.cwl must be mutated"
     runner.stage_plan = future_stage_plan()
 
     runner.run_range(up_to=Stage.prepare)

--- a/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
+++ b/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
@@ -6,6 +6,7 @@ License: GPLv3+
 """
 
 import json
+import shutil
 from pathlib import Path
 
 from picongpu.picmi import Cartesian3DGrid, ElectromagneticSolver, Stage, Simulation
@@ -15,6 +16,7 @@ from picongpu.pypicongpu.runner import (
     StageStepSpec,
     StepOutputRef,
     WorkflowPrerequisiteError,
+    WorkflowStageError,
 )
 from pytest import fixture, raises
 
@@ -372,6 +374,16 @@ def test_missing_prerequisite_is_an_error(runner):
 
     with raises(ValueError, match="after up_to"):
         runner.run_range(from_=Stage.collect, up_to=Stage.build)
+
+
+def test_step_file_renamed_raises_workflow_stage_error(runner):
+    # a missing (renamed) step file is a cwltool load/validation failure; the
+    # documented error contract is WorkflowStageError, not a raw cwltool exception
+    steps_dir = runner.workflow_dir_path / "steps"
+    shutil.move(str(steps_dir / "build.cwl"), str(steps_dir / "compile.cwl"))
+
+    with raises(WorkflowStageError, match="loading/running CWL step"):
+        runner.run_range(up_to=Stage.build)
 
 
 def test_force_stage_invalidates_dependents(runner):

--- a/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
+++ b/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
@@ -299,7 +299,18 @@ def set_workflow_input(runner, key, value):
 def test_full_run_default_and_state(runner, sim):
     # Default (no arguments) runs the whole pipeline; progress is recorded
     # in the stage-keyed state file.
-    sim.picongpu_run()
+    artifacts = runner.run_range()
+
+    # the default full run returns the recorded artifacts of the last stage
+    # (the same shape as the per-step path), not the raw workflow outputs
+    assert set(artifacts) == {
+        "input_directory",
+        "tbg_directory",
+        "submission_information",
+        "link_results_script",
+    }
+    for artifact in artifacts.values():
+        assert set(artifact) == {"class", "location"}
 
     run_dir = runner.run_dir
     assert (run_dir / "input" / "bin" / "picongpu").read_text() == "built-default\n"
@@ -325,7 +336,8 @@ def test_second_run_skips_completed(runner, sim):
     sim.picongpu_run()
     first = load_state(runner)
 
-    sim.picongpu_run()
+    # an up-to-date re-run executes no stage at all and returns None
+    assert runner.run_range() is None
 
     second = load_state(runner)
     assert first == second, "a second run must not redo (or even rewrite) completed stages"

--- a/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
+++ b/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
@@ -1,0 +1,466 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: opencode
+License: GPLv3+
+"""
+
+import json
+from pathlib import Path
+
+from picongpu.picmi import Cartesian3DGrid, ElectromagneticSolver, Stage, Simulation
+from picongpu.pypicongpu.runner import (
+    DEFAULT_STAGE_PLAN,
+    StageArtifactRef,
+    StageStepSpec,
+    StepOutputRef,
+    WorkflowPrerequisiteError,
+)
+from pytest import fixture, raises
+
+
+# Tiny echo replacements for the real CWL steps. They keep the same input
+# names/types as the production steps (see templates/workflow/steps/*.cwl) so
+# that the default stage plan can drive them, but only do file bookkeeping.
+# The build step echoes the (optional) cmake argument into the "binary", so a
+# changed build input visibly changes the artifact content.
+ECHO_BUILD_CWL = """
+cwlVersion: v1.2
+class: CommandLineTool
+label: "Build PIConGPU (test echo)"
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: include
+        entry: $(inputs.include_directory)
+      - entryname: build.sh
+        entry: $(inputs.script)
+# note: with `bash -c`, the first argument after the command string is $0,
+# so CWL input position 4 (cmake) arrives as $3 here
+baseCommand: ["bash", "-c", "mkdir -p bin && echo built-${3:-default} > bin/picongpu"]
+inputs:
+  include_directory:
+    type: Directory
+    inputBinding:
+      position: 1
+  script:
+    type: File
+    inputBinding:
+      position: 2
+  jobs:
+    type: int?
+    inputBinding:
+      position: 3
+  cmake:
+    type: string?
+    inputBinding:
+      position: 4
+  preset:
+    type: int?
+    inputBinding:
+      position: 5
+  force:
+    type: boolean
+    inputBinding:
+      position: 6
+  cmake_build_system:
+    type: string?
+    inputBinding:
+      position: 7
+outputs:
+  bin_directory:
+    type: Directory
+    outputBinding:
+      glob: "bin"
+"""
+
+ECHO_PREPARE_SUBMISSION_CWL = """
+cwlVersion: v1.2
+class: CommandLineTool
+label: "Prepare submission (test echo)"
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: etc
+        entry: $(inputs.etc_directory)
+      - entryname: prepare_submission.sh
+        entry: $(inputs.script)
+baseCommand: ["bash", "-c", "mkdir -p run_dir/tbg && echo prepared > run_dir/tbg/marker.txt"]
+inputs:
+  etc_directory:
+    type: Directory
+  script:
+    type: File
+  template_file:
+    type: string?
+  cfg_file:
+    type: string
+  overwrite_vars:
+    type: string?
+  force:
+    type: boolean
+outputs:
+  tbg_directory:
+    type: Directory
+    outputBinding:
+      glob: "run_dir/tbg"
+"""
+
+ECHO_SUBMIT_CWL = """
+cwlVersion: v1.2
+class: CommandLineTool
+label: "Submit (test echo)"
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: submit.sh
+        entry: $(inputs.script)
+      - entryname: bin
+        entry: $(inputs.bin_directory)
+      - entryname: tbg_link
+        entry: $(inputs.tbg_link)
+      - entryname: etc
+        entry: $(inputs.etc_directory)
+baseCommand: ["bash", "-c", "cp -rL tbg_link tbg && cp -rL bin/picongpu tbg/bin_from_build && \
+echo fake-job-42 > submission_information.txt && \
+echo 'ln -s /stable/simOutput $1' > link_results.sh && chmod +x link_results.sh"]
+inputs:
+  script:
+    type: File
+  bin_directory:
+    type: Directory
+  tbg_link:
+    type: Directory
+  etc_directory:
+    type: Directory
+  submit_system:
+    type: string?
+  destination_path:
+    type: string?
+outputs:
+  submission_information:
+    type: File
+    outputBinding:
+      glob: "submission_information.txt"
+  link_results_script:
+    type: File
+    outputBinding:
+      glob: "link_results.sh"
+  tbg_directory:
+    type: Directory
+    outputBinding:
+      glob: "tbg"
+"""
+
+ECHO_ORGANIZE_OUTPUT_CWL = """
+cwlVersion: v1.2
+class: CommandLineTool
+label: "Organize output (test echo)"
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: organize_output.sh
+        entry: $(inputs.script)
+      - entryname: project_path
+        entry: $(inputs.project_path)
+      - entryname: bin
+        entry: $(inputs.bin_directory)
+      - entryname: tbg
+        entry: $(inputs.tbg_directory)
+      - entryname: submission_information
+        entry: $(inputs.submission_information)
+      - entryname: link_results
+        entry: $(inputs.link_results_script)
+baseCommand: ["bash", "-c", "cp -rL project_path input && cp -rL bin input/bin && \
+mv submission_information submission_information.txt && mv link_results link_results.sh"]
+inputs:
+  script:
+    type: File
+  project_path:
+    type: Directory
+  bin_directory:
+    type: Directory
+  tbg_directory:
+    type: Directory
+  submission_information:
+    type: File
+  link_results_script:
+    type: File
+outputs:
+  input_directory:
+    type: Directory
+    outputBinding:
+      glob: "input"
+  tbg_directory:
+    type: Directory
+    outputBinding:
+      glob: "tbg"
+  submission_information:
+    type: File
+    outputBinding:
+      glob: "submission_information.txt"
+  link_results_script:
+    type: File
+    outputBinding:
+      glob: "link_results.sh"
+"""
+
+# An extra CWL step that a "future" workflow might insert inside the submit
+# stage (e.g. uploading files to a cluster before submitting).
+ECHO_UPLOAD_CWL = """
+cwlVersion: v1.2
+class: CommandLineTool
+label: "Upload (test echo, future step)"
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: tbg_link
+        entry: $(inputs.tbg_link)
+baseCommand: ["bash", "-c", "cp -rL tbg_link uploaded && echo uploaded > uploaded/upload.log"]
+inputs:
+  tbg_link:
+    type: Directory
+outputs:
+  uploaded:
+    type: Directory
+    outputBinding:
+      glob: "uploaded"
+"""
+
+
+DUMMY_STEPS = {
+    "build.cwl": ECHO_BUILD_CWL,
+    "prepare_submission.cwl": ECHO_PREPARE_SUBMISSION_CWL,
+    "submit.cwl": ECHO_SUBMIT_CWL,
+    "organize_output.cwl": ECHO_ORGANIZE_OUTPUT_CWL,
+}
+
+
+def install_dummy_workflow(runner, extra_steps=None):
+    """Replace the generated workflow steps with fast echo versions."""
+    steps_dir = runner.workflow_dir_path / "steps"
+    steps = dict(DUMMY_STEPS)
+    if extra_steps:
+        steps.update(extra_steps)
+    for name, content in steps.items():
+        (steps_dir / name).write_text(content)
+
+
+@fixture
+def sim():
+    number_of_cells = 32
+    cell_size = 1
+    return Simulation(
+        time_step_size=17,
+        max_steps=4,
+        solver=ElectromagneticSolver(
+            method="Yee",
+            grid=Cartesian3DGrid(
+                number_of_cells=[number_of_cells, number_of_cells, number_of_cells],
+                lower_bound=[0, 0, 0],
+                upper_bound=list(map(lambda x: number_of_cells * x, [cell_size, cell_size, cell_size])),
+                # required, otherwise won't spawn
+                lower_boundary_conditions=["open", "open", "periodic"],
+                upper_boundary_conditions=["open", "open", "periodic"],
+            ),
+        ),
+    )
+
+
+@fixture
+def runner(sim):
+    r = sim.picongpu_get_runner()
+    r.generate()
+    install_dummy_workflow(r)
+    return r
+
+
+def load_state(runner):
+    if not runner.workflow_state_path.is_file():
+        return {"stages": {}}
+    with runner.workflow_state_path.open("r") as file:
+        return json.load(file)
+
+
+def completed_stages(runner):
+    return set(load_state(runner)["stages"])
+
+
+def set_workflow_input(runner, key, value):
+    with runner.workflow_input_path.open("r") as file:
+        workflow_input = json.load(file)
+    workflow_input[key] = value
+    with runner.workflow_input_path.open("w") as file:
+        json.dump(workflow_input, file, indent=4)
+
+
+def test_full_run_default_and_state(runner, sim):
+    # Default (no arguments) runs the whole pipeline; progress is recorded
+    # in the stage-keyed state file.
+    sim.picongpu_run()
+
+    run_dir = runner.run_dir
+    assert (run_dir / "input" / "bin" / "picongpu").read_text() == "built-default\n"
+    assert (run_dir / "tbg" / "marker.txt").read_text() == "prepared\n"
+    assert (run_dir / "tbg" / "bin_from_build").read_text() == "built-default\n"
+    assert (run_dir / "submission_information.txt").read_text() == "fake-job-42\n"
+    assert "ln -s /stable/simOutput $1" in (run_dir / "link_results.sh").read_text()
+
+    state = load_state(runner)
+    assert state["version"] == 1
+    assert set(state["stages"]) == {stage.value for stage in Stage}
+    for entry in state["stages"].values():
+        assert entry["status"] == "completed"
+        assert entry["artifacts"]
+        for artifact in entry["artifacts"].values():
+            assert set(artifact) == {"class", "location"}
+            assert artifact["class"] in ("File", "Directory")
+    # the state is keyed by stages, never by CWL step names
+    assert "build_step" not in json.dumps(state)
+
+
+def test_second_run_skips_completed(runner, sim):
+    sim.picongpu_run()
+    first = load_state(runner)
+
+    sim.picongpu_run()
+
+    second = load_state(runner)
+    assert first == second, "a second run must not redo (or even rewrite) completed stages"
+
+
+def test_range_build_only(runner):
+    runner.run_range(up_to=Stage.build)
+
+    state = load_state(runner)
+    assert set(state["stages"]) == {Stage.build.value}
+    bin_directory = state["stages"][Stage.build.value]["artifacts"]["bin_directory"]
+    assert ".stage_outputs" in bin_directory["location"]
+    assert (Path(bin_directory["location"]) / "picongpu").read_text() == "built-default\n"
+
+
+def test_incremental_stage_scenario(runner):
+    # build only, then prepare only, then submit only, then collect only;
+    # each run skips the stages that are already completed.
+    runner.run_range(up_to=Stage.build)
+    assert completed_stages(runner) == {Stage.build.value}
+
+    runner.run_range(up_to=Stage.prepare)
+    assert completed_stages(runner) == {Stage.build.value, Stage.prepare.value}
+
+    runner.run_range(from_=Stage.submit, up_to=Stage.submit)
+    assert completed_stages(runner) == {Stage.build.value, Stage.prepare.value, Stage.submit.value}
+
+    runner.run_range(from_=Stage.collect)
+    assert completed_stages(runner) == {stage.value for stage in Stage}
+
+    # the final artifacts end up in the same place as a full run, and the
+    # artifacts of the earlier stages flowed through the stages
+    run_dir = runner.run_dir
+    assert (run_dir / "input" / "bin" / "picongpu").read_text() == "built-default\n"
+    assert (run_dir / "tbg" / "marker.txt").read_text() == "prepared\n"
+    assert (run_dir / "tbg" / "bin_from_build").read_text() == "built-default\n"
+    assert (run_dir / "submission_information.txt").read_text() == "fake-job-42\n"
+
+
+def test_missing_prerequisite_is_an_error(runner):
+    # starting at a stage whose prerequisites never ran must fail, not
+    # silently (re)run them
+    with raises(WorkflowPrerequisiteError, match="build, prepare"):
+        runner.run_range(from_=Stage.submit)
+    assert completed_stages(runner) == set()
+
+    with raises(ValueError, match="after up_to"):
+        runner.run_range(from_=Stage.collect, up_to=Stage.build)
+
+
+def test_force_stage_invalidates_dependents(runner):
+    runner.run_range()
+    state = load_state(runner)
+    prepare_updated_before = state["stages"][Stage.prepare.value]["updated_at"]
+
+    # change the build input and force a rebuild: the build and everything
+    # downstream of it (submit, collect) is re-run, prepare is skipped
+    set_workflow_input(runner, "build_cmake", "v2")
+    runner.run_range(up_to=Stage.submit, force=Stage.build)
+
+    state = load_state(runner)
+    bin_directory = state["stages"][Stage.build.value]["artifacts"]["bin_directory"]["location"]
+    assert ".stage_outputs" in bin_directory
+    assert (Path(bin_directory) / "picongpu").read_text() == "built-v2\n"
+    assert state["stages"][Stage.prepare.value]["updated_at"] == prepare_updated_before
+    assert state["stages"][Stage.prepare.value]["status"] == "completed"
+    assert state["stages"][Stage.submit.value]["status"] == "completed"
+    assert state["stages"][Stage.submit.value]["updated_at"] != state["stages"][Stage.build.value]["updated_at"]
+    # collect is outside the range, but it is now stale
+    assert state["stages"][Stage.collect.value]["status"] == "invalidated"
+
+
+def test_flags_after_generation_are_rejected(runner, sim):
+    runner.run_range()
+    state_before = load_state(runner)
+
+    # flags can only be set at generation time; after that they must not
+    # silently change the inputs of already completed stages
+    with raises(ValueError, match="already generated"):
+        sim.picongpu_run(jobs=2)
+
+    assert load_state(runner) == state_before
+
+
+def future_stage_plan():
+    """A "future" plan where the submit stage gained an extra (upload) step."""
+    plan = DEFAULT_STAGE_PLAN.model_copy(deep=True)
+    plan.stages[Stage.submit].steps = [
+        StageStepSpec(
+            step="upload_step",
+            run="steps/upload.cwl",
+            inputs={"tbg_link": StageArtifactRef(stage=Stage.prepare, artifact="tbg_directory")},
+            outputs={"uploaded": "uploaded"},
+        ),
+        StageStepSpec(
+            step="submit_step",
+            run="steps/submit.cwl",
+            inputs={
+                "script": "submission_script",
+                "bin_directory": StageArtifactRef(stage=Stage.build, artifact="bin_directory"),
+                "etc_directory": "run_etc_directory",
+                "tbg_link": StepOutputRef(step="upload_step", output="uploaded"),
+                "submit_system": "run_submit_system",
+                "destination_path": "destination_path",
+            },
+            outputs={
+                "submission_information": "submission_information",
+                "link_results_script": "link_results_script",
+                "tbg_directory": "tbg_directory",
+            },
+        ),
+    ]
+    return plan
+
+
+def test_stability_future_workflow(runner):
+    # A future workflow with an extra step inserted inside the submit stage
+    # must keep the public API (stage names, ranges, state file) unchanged.
+    install_dummy_workflow(runner, extra_steps={"upload.cwl": ECHO_UPLOAD_CWL})
+    runner.stage_plan = future_stage_plan()
+
+    runner.run_range(up_to=Stage.prepare)
+    assert completed_stages(runner) == {Stage.build.value, Stage.prepare.value}
+
+    runner.run_range(up_to=Stage.submit)
+    state = load_state(runner)
+    assert set(state["stages"]) == {Stage.build.value, Stage.prepare.value, Stage.submit.value}
+    tbg_directory = state["stages"][Stage.submit.value]["artifacts"]["tbg_directory"]["location"]
+    # the submit step consumed the upload step's output (in-stage wiring)
+    assert (Path(tbg_directory) / "upload.log").read_text() == "uploaded\n"
+    assert (Path(tbg_directory) / "bin_from_build").read_text() == "built-default\n"
+    assert (Path(tbg_directory) / "marker.txt").read_text() == "prepared\n"
+    # the state is still keyed by stages, not by the steps inside them
+    assert "upload_step" not in json.dumps(state)
+
+    runner.run_range(from_=Stage.collect)
+    assert completed_stages(runner) == {stage.value for stage in Stage}
+    run_dir = runner.run_dir
+    assert (run_dir / "tbg" / "upload.log").exists()
+    assert (run_dir / "input" / "bin" / "picongpu").read_text() == "built-default\n"

--- a/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
+++ b/lib/python/test/picongpu/quick/picmi/test_partial_workflow.py
@@ -408,6 +408,33 @@ def test_flags_after_generation_are_rejected(runner, sim):
     assert load_state(runner) == state_before
 
 
+def test_input_change_invalidates_completed_stages(runner):
+    # editing workflow/input.yaml after a completed run must not be a silent
+    # no-op: the stage whose inputs changed (and the stages that depend on it)
+    # is re-run, while stages with unchanged inputs are still skipped.
+    runner.run_range()
+    state = load_state(runner)
+    build_digest = state["stages"][Stage.build.value]["inputs_digest"]
+    assert build_digest
+    prepare_updated_at = state["stages"][Stage.prepare.value]["updated_at"]
+
+    # the user edits a workflow input that only the build stage consumes
+    set_workflow_input(runner, "build_cmake", "v2")
+    runner.run_range()
+
+    state = load_state(runner)
+    for stage in Stage:
+        assert state["stages"][stage.value]["status"] == "completed"
+    assert state["stages"][Stage.build.value]["inputs_digest"] != build_digest
+    # prepare was not affected by the input change and was skipped
+    assert state["stages"][Stage.prepare.value]["updated_at"] == prepare_updated_at
+    # the stale build and its dependents (submit, collect) were re-run, so
+    # the new input is visible in the final artifacts (not silently skipped)
+    run_dir = runner.run_dir
+    assert (run_dir / "input" / "bin" / "picongpu").read_text() == "built-v2\n"
+    assert (run_dir / "tbg" / "bin_from_build").read_text() == "built-v2\n"
+
+
 def future_stage_plan():
     """A "future" plan where the submit stage gained an extra (upload) step."""
     plan = DEFAULT_STAGE_PLAN.model_copy(deep=True)


### PR DESCRIPTION
## What

Adds a stable `Stage` vocabulary (`build`/`prepare`/`submit`/`collect`), a
data-driven stage -> CWL-step adapter (`StagePlan`/`DEFAULT_STAGE_PLAN`), a
stage-keyed persisted state file (`run_dir/.workflow_state.json`), and
`Runner.run_range(up_to/from_/force)` exposed as
`Simulation.picongpu_run(up_to=..., from_=..., force=...)`. Python only (no
C++/template/CWL changes). **Draft** — open questions remain in
`TASK-09-FINDINGS.md` section 14.

## Rework (2026-08-31)

- **M1**: corrected the resume-after-failure docs (stage-level resume applies
  to range-started runs; a failed default run resumes only via the cwltool
  job cache for byte-identical inputs).
- **M2**: per-stage input digests in the state file; changed inputs now
  invalidate `completed` stages (and transitive dependents) instead of a
  silent no-op. This exposed and fixed a pre-existing cwltool job-cache
  bug (per-step re-runs now run with `cachedir=None`).
- m1 (ASCII-normalize findings + honest hook claim), m2 (plan <-> workflow
  sync test against the real template), m3 (wrap cwltool load/validation
  errors in `WorkflowStageError`), n1 (version check), n2 (consistent
  `run_range` return), plus the bash-preset staging-ordering caveat.

See `TASK-09-RESPONSE.md`.

## Verification

`pytest quick/` green (190), `pre-commit run --all-files` green at the
branch tip.

---
**Internal review PR** (fork `chillenzer/picongpu`). QA cycle completed on-branch: implementation -> independent review (`TASK-09-REVIEW.md`) -> rework (`TASK-09-RESPONSE.md`), all committed at the branch root alongside `TASK-09-FINDINGS.md`.

**Stacked PR**: the base is the reworked `task-05` branch, so the diff shows only this task's work. Base will be re-pointed to the upstream development branch once approved.