### PR TITLE
test: audit of testsuite/setups + cleanup and openPMD modernisation (draft)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,8 +77,11 @@ repos:
         # - CHANGELOG.md: Contains author names that might include special characters for correct spelling.
         # - .zenodo.json: Contains author names that might include special characters for correct spelling.
         # - unit_dimension.py: Contains theta as the symbol for temperature.
+        # - TASK-10-REVIEW.md: review-team artifact containing math notation
+        #   (Gamma, Delta, arrows); the task-10 rework is not allowed to
+        #   modify it, so it is excluded here instead.
         exclude_types: [rst]
-        exclude: CHANGELOG.md|.zenodo.json|lib/python/picongpu/picmi/particle_functor/unit_dimension.py
+        exclude: CHANGELOG.md|.zenodo.json|lib/python/picongpu/picmi/particle_functor/unit_dimension.py|TASK-10-REVIEW.md
   - repo: https://github.com/BlankSpruce/gersemi
     rev: 0.22.1
     hooks:

--- a/TASK-10-FINDINGS.md
+++ b/TASK-10-FINDINGS.md
@@ -311,19 +311,27 @@ simulation -- `slow`/`end_to_end` class, not unit tests.
    modernised check can consume anything.
 2. The legacy `--fields_energy` flag no longer resolves to a plugin in this
    checkout (L5), so the old `validate.sh` path is not a working fallback.
-3. A decision is needed on whether the KHI growth-rate flow is still
+3. `KHI_growthRate/bin/ci.sh` cannot be invoked as-is: it passes the dead
+   `--fields_energy.period 10` flag (ci.sh:120, L5) and ends with the dead
+   legacy `validate.sh` call (ci.sh:124, L5/B6). It must either be fixed
+   (drop the dead flag, replace the `validate.sh` call with the openPMD
+   pytest step) or bypassed, as in the corrected proposal below.
+4. A decision is needed on whether the KHI growth-rate flow is still
    load-bearing (requester: uncertain).
 
 ### 6.3 Recommendation (proposal only -- not wired into CI)
 
 Do **not** add this to the default MR pipeline: it would be the first
-simulation run ever executed in CI, it needs pre-conditions 1-2 to be met
+simulation run ever executed in CI, it needs pre-conditions 1-3 to be met
 first, and its load-bearing status is unconfirmed. Instead:
 
-**Proposed job** (to add once pre-conditions are met and the requester
+**Proposed job** (to add once pre-conditions 1-3 are met and the requester
 confirms), e.g. in a new `share/ci/run_khi_growthrate.sh` invoked by a
 GitLab job tagged `cpuonly`, `x86_64`, triggered **manually and/or on a
-scheduled (weekly) pipeline**, not per-MR:
+scheduled (weekly) pipeline**, not per-MR. It mirrors
+`KHI_growthRate/bin/ci.sh` but drops the dead `--fields_energy.period 10`
+flag and the dead `validate.sh` call (pre-condition 3), and validates the
+openPMD output with the modernised pytest check added on this branch:
 
 ```yaml
 khi-growthrate-validation:
@@ -335,22 +343,32 @@ khi-growthrate-validation:
   script:
     - source $CI_PROJECT_DIR/share/ci/install/cmake.sh && source $CI_PROJECT_DIR/share/ci/install/gcc.sh
     - source $CI_PROJECT_DIR/share/ci/install/pypicongpu.sh   # python env + pytest
-    - $CI_PROJECT_DIR/share/picongpu/tests/KHI_growthRate/bin/ci.sh <test> <outdir> --keep-logs
-      # ci.sh: pic-create + pic-build + mpiexec -n 1 ... -s 3000 + validate
+    - pic-create -f $CI_PROJECT_DIR/share/picongpu/tests/KHI_growthRate $CI_PROJECT_DIR/khi_run
+    - cd $CI_PROJECT_DIR/khi_run && pic-build
+    - mkdir -p simOutput && cd simOutput
+    - mpiexec -n 1 ../bin/picongpu -d 1 1 1 -g 192 512 12 --periodic 1 1 1 -s 3000
     - cd $CI_PROJECT_DIR/lib/python/test/picongpu
-    - PIC_KHI_OPENPMD=<outdir>/simOutput/.../openpmd python3 -m pytest
-        end_to_end/test_khi_growthrate.py -v
+    - PIC_KHI_OPENPMD=$CI_PROJECT_DIR/khi_run/simOutput/<filePrefix>/openpmd
+        python3 -m pytest end_to_end/test_khi_growthrate.py -v
+      # <filePrefix>: the openPMD file prefix of the picongpu.cfg added per
+      # pre-condition 1 (the input set writes no openPMD output until then)
 ```
 
-- Cost: ~15-40 min of one CPU runner per run (weekly = < 5 h/week).
+- Cost: ~15-40 min of one CPU runner per run (weekly = < 1 h/week of one
+  CPU runner).
 - Benefit: continuous physics regression signal for KHI + openPMD field
   output + the validation pipeline itself; failures surface as a normal CI
   job failure instead of an exit code in a manual log.
 - Cheaper alternative for the *pipeline logic only*: run the synthetic
-  `test_khi_growthrate.py` in the existing `pypicongpu` job (it is fast,
-  < 2 s) -- this needs a one-line change in `share/ci/install/pypicongpu.sh`
-  and would also guard against the L7 class of environment regressions;
-  propose, don't wire.
+  `test_khi_growthrate.py` in the existing `pypicongpu` quick job -- it is
+  fast (< 2 s) and would also guard against the L7 class of environment
+  regressions. The change is one line in `share/ci/install/pypicongpu.sh`,
+  after `python3 -m pytest quick/`:
+  `python3 -m pytest end_to_end/test_khi_growthrate.py -q`. The
+  auto-applied `slow`/`end_to_end` markers are metadata only (no `-m`
+  filter is active there), and `test_real_khi_run_validation` self-skips
+  without `PIC_KHI_OPENPMD`. Propose, don't wire: adopting it is the
+  requester's call along with the open question below.
 
 **Open question for the requester:** slow job on the main pipeline vs
 manual/periodic trigger (recommendation above: manual/periodic until the

--- a/TASK-10-FINDINGS.md
+++ b/TASK-10-FINDINGS.md
@@ -16,7 +16,7 @@ costed recommendation for CI integration.
 Not a pytest suite. It is a self-contained **post-simulation validation
 framework** (origin 2022-12-09, last functional commit
 `0e3f64f3f` 2024-02-28 "fix growth rate and charge conservation test tools";
-bachelor-thesis work per file headers). 21 Python files, ~3000 lines, ~75 KB
+bachelor-thesis work per file headers). 21 Python files, ~2600 lines, ~75 KB
 (plus 4 files in `setups/`).
 
 Pipeline: `setups/<case>/main.py` (argparse CLI) ->
@@ -69,7 +69,7 @@ CI is GitLab-based (`.gitlab-ci.yml` + `share/ci/`). Verified facts:
 3. No CI script references KHI:
    `grep -rn KHI .gitlab-ci.yml share/ci/` -> no matches.
 4. The sole consumer of the framework is
-   `share/picongpu/tests/KHI_growthRate/bin/validate.sh:65-66`:
+   `share/picongpu/tests/KHI_growthRate/bin/validate.sh:67`:
    `python $PICSRC/lib/python/test/setups/ESKHI/main.py -p ... -r ... -s ...`,
    which is invoked only by the **manual** `KHI_growthRate/bin/ci.sh`
    (`pic-create` + `pic-build` +
@@ -94,7 +94,9 @@ $ PY -c "import sys; sys.path.insert(0,'lib/python/test'); import numpy as np, t
 0.346574 0.693147   # returned Gamma/2 (ratio 0.5000 in both branches)
 ```
 Skewed the verdict of *both* setups (sim rate measured at half value; a
-simulation matching theory would appear at ~-50 % deviation).
+simulation matching theory would appear at ~+50 % deviation
+(`getDifferenceInPercentage(Gamma, Gamma/2)` = +50, i.e. |deviation|
+50 % > 20 % acceptance -> fail)).
 
 **B2 - `Math/deviation.py::getMinDifference` crashed on scalars, ambiguous on 2-D.**
 `np.abs(min(theory - simulation))` uses the built-in `min()` -- although this
@@ -129,7 +131,7 @@ ReadFiles(".dat", direction="/tmp").setDirection("/tmp")
 `ParamReader.paramInLine` (paramReader.py:193) and
 `CMAKEFlagReader.getAllSetups` (cmakeFlagReader.py:98) opened files without
 closing them. Under the repo's pytest regime (`filterwarnings = ["error"]`
-in `lib/python/pyproject.toml:88`) the resulting `ResourceWarning` fails any
+in `lib/python/pyproject.toml:92`) the resulting `ResourceWarning` fails any
 test exercising the parsers -- one of the reasons the framework has zero
 tests (the global config state, L3, and the missing fixtures are at least
 equally plausible). Both file-handle fixes have regression tests:

--- a/TASK-10-FINDINGS.md
+++ b/TASK-10-FINDINGS.md
@@ -1,0 +1,368 @@
+# TASK-10 — Audit of `lib/python/test/{testsuite,setups}`: what are they testing, what is their quality?
+
+Branch: `task-10-testsuite-audit` (base `dev` @ b4e4ca5b2) · Date: 2026-08-29
+
+This document answers the two audit questions — *what are they testing?* and
+*what is their quality?* — with verified defects (reproducible commands),
+summarises the cleanup and modernisation commits on this branch, and gives a
+costed recommendation for CI integration.
+
+---
+
+## 1. What are they?
+
+### 1.1 `lib/python/test/testsuite/` — a standalone post-simulation validation framework
+
+Not a pytest suite. It is a self-contained **post-simulation validation
+framework** (origin 2022-12-09, last functional commit
+`0e3f64f3f` 2024-02-28 "fix growth rate and charge conservation test tools";
+bachelor-thesis work per file headers). 21 Python files, ~3000 lines, ~75 KB
+(plus 4 files in `setups/`).
+
+Pipeline: `setups/<case>/main.py` (argparse CLI) →
+`testsuite._manager.run_testsuite()` →
+`Reader` (crude parsers for `.param` preprocessor-style files, `.json`,
+`.dat` columns, `cmakeFlags`) → `config.theory(**parameter)` vs
+`config.simData(**parameter)` (the case's analytic theory and the simulated
+quantity) → `Math._manager._calculate` (deviation checks) →
+`Output` (`testresult.log` + matplotlib PNG) → `sys.exit(0/1/42)`.
+
+### 1.2 `lib/python/test/setups/` — the two concrete cases
+
+| Case | Title | Theory (units of ω_pe) | Simulated quantity | Acceptance |
+|---|---|---|---|---|
+| `ESKHI/` | KHI Growthrate (2D ESKHI) | `1/(√8·γ)` | growth rate of the `Bx` column of `fields_energy.dat` | 20 % |
+| `MI/` | KHI Growthrate (2D MI) | `v/(c·√γ)` with `v=√(1−1/γ²)·c` | growth rate of `Bx`, trimmed at the first local minimum | 20 % |
+
+Both measure the Kelvin–Helmholtz instability growth rate of the dominant
+magnetic field in a sub-relativistic shear-flow simulation
+([Alves12], [Grismayer13], [Bussmann13]; see
+`share/picongpu/tests/KHI_growthRate/README.rst`) and pass if the simulated
+growth rate is within 20 % of the analytic value.
+
+### 1.3 What they are NOT (and are not part of)
+
+- **Not pytest**: no `test_*.py`/`*_test.py` files, no `assert`s.
+  `cd lib/python && python -m pytest test/testsuite test/setups --collect-only -q`
+  → **`no tests collected`** (0 items).
+- **Not imported by the `picongpu` package** (zero cross-imports; the package
+  is installed from `lib/python/picongpu`, the framework lives in
+  `lib/python/test/`).
+- **Not run by CI** (see §2).
+- **Not duplicated** by the new `test/picongpu/` suite (2025 rewrite with
+  `quick/`/`compiling/`/`end_to_end/`): different purpose — physics
+  post-processing of real simulation output vs. package unit/integration
+  tests.
+
+## 2. Are they tested in CI? — No
+
+CI is GitLab-based (`.gitlab-ci.yml` + `share/ci/`). Verified facts:
+
+1. The Python package jobs run only the new suite:
+   `share/ci/install/pypicongpu.sh:61-65` —
+   `pip3 install -e lib/python[test]` then
+   `cd lib/python/test/picongpu && python3 -m pytest quick/`;
+   line 97: `python3 -m pytest compiling/ -v` (compile job only).
+2. `share/picongpu/tests/*` jobs (`share/ci/run_picongpu_tests.sh`) only
+   **compile** each test case and run a `picongpu --help` smoke test —
+   **no simulation is ever executed in CI**.
+3. No CI script references KHI:
+   `grep -rn KHI .gitlab-ci.yml share/ci/` → no matches.
+4. The sole consumer of the framework is
+   `share/picongpu/tests/KHI_growthRate/bin/validate.sh:65-66`:
+   `python $PICSRC/lib/python/test/setups/ESKHI/main.py -p ... -r ... -s ...`,
+   which is invoked only by the **manual** `KHI_growthRate/bin/ci.sh`
+   (`pic-create` + `pic-build` +
+   `mpiexec -n 1 picongpu ... -s 3000 --fields_energy.period 10`), i.e. a
+   local/manual workflow, never by CI.
+
+## 3. Quality: verified defects (with evidence)
+
+All reproductions run in a clean shell; `PY=.../venvs/task-10/bin/python`,
+`T=lib/python/test` (worktree root).
+
+### 3.1 Computational bugs (fixed on this branch)
+
+**B1 — `Math/math.py::growthRate` returned half the growth rate.**
+The docstring formula `log(f(t_{k+1})/f(t_{k-1}))/(t_{k+1}−t_{k-1})` is a
+two-step centred difference that already yields Γ per unit time; the code
+multiplied by `0.5`, double-correcting the two-step span.
+
+```
+$ PY -c "import sys; sys.path.insert(0,'lib/python/test'); import numpy as np, testsuite.Math.math as m;
+         t=np.arange(50.0); g=m.growthRate(2.0**t, t); print(np.mean(g), np.log(2))"
+0.346574 0.693147   # returned Γ/2 (ratio 0.5000 in both branches)
+```
+Skewed the verdict of *both* setups (sim rate measured at half value; a
+simulation matching theory would appear at ~−50 % deviation).
+
+**B2 — `Math/deviation.py::getMinDifference` crashed on scalars, ambiguous on 2-D.**
+`np.abs(min(theory - simulation))` uses the built-in `min()` — although this
+function is part of the main pipeline (`Math/_manager.py:20 _calculate`).
+
+```
+getMinDifference(0.5, 0.5)            # TypeError: 'float' object is not iterable
+getMinDifference(ones((2,3)), ...)    # ValueError: truth value of array ambiguous
+```
+
+**B3 — `Math/deviation.py::getDifferenceInPercentage` docstring/code mismatch.**
+Docstring: `(theory − max(simulation)) / simulation * 100`; code:
+`(theory − max(simulation)) / theory * 100`. The code's semantics (relative
+to theory) are the ones `getTestResult` and the acceptance range
+(`theory·(1±acceptance)`) rely on, so the docstring was corrected; also
+`max(simulation)` raised `TypeError` for scalar simulation values
+(`np.max` now).
+
+```
+getDifferenceInPercentage(2.0, [1.0, 1.5])  # code: 25.0, docstring formula: 33.33
+```
+
+**B4 — `Reader/readFiles.py::setDirection` — `AttributeError`.**
+Referenced `self.directiontype`; the attribute is `self._directiontype`.
+
+```
+ReadFiles(".dat", direction="/tmp").setDirection("/tmp")
+# AttributeError: 'ReadFiles' object has no attribute 'directiontype'
+```
+
+**B5 (additional, found & fixed) — unclosed file handles.**
+`ParamReader.paramInLine` (paramReader.py:193) and
+`CMAKEFlagReader.getAllSetups` (cmakeFlagReader.py:98) opened files without
+closing them. Under the repo's pytest regime (`filterwarnings = ["error"]`
+in `lib/python/pyproject.toml:88`) the resulting `ResourceWarning` fails any
+test exercising the parsers — this is why the framework has zero tests.
+
+**B6 (additional, found & fixed) — `DataReader.getValue` could not read the
+file format its own `allParamsinFile` defines.** `allParamsinFile` treats
+the first `.dat` line as the column-name header; `getValue` then read the
+same file with `np.loadtxt` (no `skiprows`), which dies on the header:
+
+```
+headered  file -> getValue('Bx'): ValueError: could not convert string 'step' to float64 at row 0
+headerless file -> getValue('Bx'): ValueError: The given Parameter could not be found
+```
+i.e. the "simulation data" leg of the whole pipeline was dead for both
+possible on-disk formats. Fixed with `skiprows=1` (only reachable via
+headered files, since the sought parameter name is non-numeric, so no data
+row can ever be dropped).
+
+### 3.2 Latent defects (documented, NOT fixed — see scope note)
+
+- **L1 — `Math/_searchData.py::searchParameter(directiontype="openpmd")`**
+  validates `"openpmd"` as a legal direction type but implements no branch
+  for it → `UnboundLocalError: cannot access local variable 'result'`. The
+  framework's advertised openPMD support was never written (no
+  `openPMDReader` exists). The modernisation (§5) supplies a real openPMD
+  path instead.
+- **L2 — `setups/ESKHI/main.py` and `setups/MI/main.py` parse `-o
+  <openPMD dir>` but never pass it to `run_testsuite`** (dead option).
+- **L3 — `_checkData.py` uses `eval("config."+name)` / `exec(...)`** to read
+  and *write* the global `config` module (e.g. `checkDirection` persists
+  resolved directories into it). Stateful, fragile, and the reason any test
+  of the framework must reset global config between tests.
+- **L4 — `Output/Viewer.py::plot_2D` is an empty stub**;
+  `_manager.py` blanket-catches `Exception` → `sys.exit(42)` (real errors
+  surface only as `error.log` + exit code 42).
+- **L5 — the KHI flow's data source is gone.** `ci.sh` passes
+  `--fields_energy.period 10`, but no `fields_energy`/`fieldsEnergy`
+  plugin/option exists anywhere in this checkout (only a stale reference in
+  `src/tools/bin/plotNumericalHeating` docs and the same flag in
+  `tests/FieldAbsorber`). If it is also gone upstream, the KHI flow has been
+  dead since the diagnostic was removed — the "load-bearing status
+  uncertain" flag is therefore well placed.
+- **L6 — the KHI input set has no openPMD diagnostics.**
+  `share/picongpu/tests/KHI_growthRate/` contains no
+  `etc/picongpu/picongpu.cfg`, so the current test does not write openPMD
+  fields at all. The modernised openPMD check (§5) cannot run on it until a
+  `picongpu.cfg` with a field dump for `B` is added (follow-up, §7).
+- **L7 — environment: openpmd-api's read path is broken for Python 3.14 in
+  this container.** Write works (files verified correct byte-for-byte via
+  h5py: correct groups, `time`/`dt` attributes, dataset contents), but
+  `load_chunk()` returns swapped/corrupted data — e.g. a 2-iteration scalar
+  series reads back `[2.0, 1.0]` instead of `[1.0, 2.0]`, identical for
+  openpmd-api 0.16.1 and 0.17.1.post4, h5 and BP backends, all read
+  patterns. The project targets Python `>=3.11,<3.14`
+  (`lib/python/pyproject.toml`) and CI runs 3.11/3.12/3.13
+  (`share/ci/pypicongpu_generator.py:316`); the 3.14 wheel here is outside
+  the supported range. The new tests therefore self-check the read path and
+  skip with a clear message when it is broken (this container); they run on
+  CI's Python versions.
+
+### 3.3 Stale documentation (fixed on this branch)
+
+- `docs/source/testing/structure.rst` referenced `Template/Data.py` and
+  `Template/main.py` (neither exists; the template is `Template/config.py`)
+  and omitted `Reader/readFiles.py`/`cmakeFlagReader.py`.
+- `docs/source/testing/testbuilding.rst` described the obsolete "Data.py"
+  workflow, had a typo'd path (`.lib/python/...`), and its MI example did
+  not match `setups/MI/config.py` (`Bz` vs `Bx`, `*args` vs `**kwargs`,
+  `calculateV_O()` vs `calculateV_O(gamma)`).
+- `docs/source/testing/usage.rst` pointed at the non-existent
+  `testsuite/Template/main.py --help` and claimed the output folder is
+  deleted by default (it is kept; `--delete` removes it).
+
+### 3.4 Quality summary
+
+- Zero automated tests, zero asserts; "pass" = one 20 % deviation check per
+  case, reported via log file + exit code.
+- 6 real defects on the core computation/reader path (4 pre-existing named
+  + 2 found during this audit), all fixed on this branch with regression
+  tests; 7 documented latent/environmental defects.
+- Untouched functionally since 2024-02 while the rest of the Python package
+  was rewritten in 2025; the data source it parses (`fields_energy.dat`) is
+  no longer produced by this checkout (L5), and the KHI input set produces
+  no openPMD fields (L6) — the flow is likely already non-functional end to
+  end.
+
+## 4. Quick cleanup (commits b4e4ca5b2..997037074)
+
+| Commit | Change |
+|---|---|
+| `256384619` | `Math/math.py`: remove the spurious factor 1/2 in `growthRate` (B1) |
+| `f8c9b0dd8` | `Math/deviation.py`: `getMinDifference` via `np.min` (B2); `getDifferenceInPercentage` docstring aligned to the (intended) theory-relative semantics + `np.max` (B3); `getMaxDifference` via `np.max` (same class as B2) |
+| `24c26adad` | `Reader/readFiles.py`: `setDirection` uses `self._directiontype` (B4) |
+| `7e5501907` | `Reader/paramReader.py`, `Reader/cmakeFlagReader.py`: close file handles (B5) |
+| `528666828` | `Reader/dataReader.py`: `getValue` skips the header line (`skiprows=1`) (B6) |
+| `a884ba3ba` | New unit tests `lib/python/test/picongpu/quick/testsuite/` (27 tests): `growthRate` (incl. the factor-1/2 regression), deviation helpers, physics helpers, `.param`/`.dat`/`.json` parsers, `ReadFiles` (incl. the `setDirection` regression). A `conftest.py` makes the standalone `testsuite` package importable and resets the global template-config state between tests (L3) |
+| `997037074` | Fix the three stale docs (`structure`/`testbuilding`/`usage.rst`) |
+
+Gate: `pytest quick/` went from `174 passed, 2 xfailed, 1 xpassed` to
+`201 passed, 2 xfailed, 1 xpassed` (all new tests pass; nothing deleted).
+
+## 5. Modernisation (commit b921eb8e2)
+
+`lib/python/test/picongpu/end_to_end/khi_growthrate.py` re-expresses the
+ESKHI validation as openPMD-consuming checks:
+
+- `bx_amplitude_per_iteration(series)` — f(t) = max|Bx| per iteration from
+  the openPMD series (`meshes["B"]["x"]`, the same access pattern as
+  `end_to_end/compare_particles.py::read_fields`); this replaces the
+  `fields_energy.dat` `Bx` column.
+- `times_omega_pe(series, density_si, gamma)` — openPMD `time` (SI) ×
+  relativistic plasma frequency; replaces the `step` column ×
+  `DELTA_T_SI` from `.dat`/`.param`.
+- `eskhi_growthrate_theory(gamma)` = `1/(√8·γ)` (same as
+  `setups/ESKHI/config.py::theory`).
+- `validate_eskhi_growthrate(path, gamma, density_si, acceptance=0.2)` —
+  **reuses the corrected `testsuite.Math` (`growthRate`,
+  `getMinDifference`, `getDifferenceInPercentage`, `getTestResult`) as the
+  reference**, so the new path and the legacy path share one computation.
+
+`lib/python/test/picongpu/end_to_end/test_khi_growthrate.py` (auto-marked
+`slow`+`end_to_end` by `test/picongpu/conftest.py`):
+
+- synthetic openPMD series whose Bx grows with the analytic esKHI rate →
+  asserts the pipeline recovers the analytic rate and the verdict is
+  `passed` (exercises openPMD read → growth rate → analytic comparison);
+- `test_real_khi_run_validation` — validates a real KHI openPMD output
+  provided via `PIC_KHI_OPENPMD` (defaults for `PIC_KHI_GAMMA`/
+  `PIC_KHI_DENSITY_SI` taken from the KHI test's `.param` files: γ=1.021,
+  n=1e25).
+
+Verification status: the full pipeline was verified end-to-end here by
+running `validate_eskhi_growthrate` over the synthetic series with the
+openpmd read layer substituted by an h5py-backed equivalent (files verified
+correct on disk) — theory `0.22097086912079605` vs simulation
+`0.22097086912079608`, verdict `True`. The only part not executed in this
+container is the literal `openpmd_api.load_chunk()` call, because of L7
+(openpmd-api's 3.14 read path is broken here); the tests therefore
+self-check the read path and skip with a clear message in broken
+environments, running on CI's Python 3.11–3.13.
+
+Nothing was deleted: the legacy `.dat`/`.param` path (`setups/`,
+`Reader/dataReader`, `Reader/paramReader`) is untouched and remains the
+fallback; it can be retired once the openPMD check is proven on a real run
+and the flow's future is decided.
+
+## 6. CI integration investigation
+
+**Question:** should these validations run regularly as part of the test
+suite / CI? They are physics post-processing of a *real* 3000-step
+simulation — `slow`/`end_to_end` class, not unit tests.
+
+### 6.1 Cost of one run (CPU runner, single config)
+
+| Step | Cost estimate | Notes |
+|---|---|---|
+| `pic-create` + `pic-build` (KHI only, 1 config) | ~10–20 min | as done by existing compile jobs; single case, `PIC_CI_COMPILE`-style flags |
+| `mpiexec -n 1 picongpu -g 192 512 12 -s 3000` | ~5–20 min (unmeasured) | 1.18 M cells, 3000 steps, 1 rank on a cpuonly runner; **no in-repo benchmark exists — CI never runs any simulation**; to be measured on a real runner |
+| Validation (openPMD read + pytest) | < 1 min | 300 iterations × Bx(192×512×12) |
+| **Total** | **~15–40 min per job** | one cpuonly runner slot |
+
+### 6.2 Pre-conditions (not met today)
+
+1. The KHI input set writes **no openPMD fields** (L6): a
+   `etc/picongpu/picongpu.cfg` with a field dump of `B` (period ≈ 10) must
+   be added to `share/picongpu/tests/KHI_growthRate/` before the
+   modernised check can consume anything.
+2. The legacy `--fields_energy` flag no longer resolves to a plugin in this
+   checkout (L5), so the old `validate.sh` path is not a working fallback.
+3. A decision is needed on whether the KHI growth-rate flow is still
+   load-bearing (requester: uncertain).
+
+### 6.3 Recommendation (proposal only — not wired into CI)
+
+Do **not** add this to the default MR pipeline: it would be the first
+simulation run ever executed in CI, it needs pre-conditions 1–2 to be met
+first, and its load-bearing status is unconfirmed. Instead:
+
+**Proposed job** (to add once pre-conditions are met and the requester
+confirms), e.g. in a new `share/ci/run_khi_growthrate.sh` invoked by a
+GitLab job tagged `cpuonly`, `x86_64`, triggered **manually and/or on a
+scheduled (weekly) pipeline**, not per-MR:
+
+```yaml
+khi-growthrate-validation:
+  stage: test
+  image: <same alpaka-ci image as .base_pypicongpu_quick_test>
+  tags: [cpuonly, x86_64]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'   # or: - if: '$CI_COMMIT_BRANCH == "dev"' + when: manual
+  script:
+    - source $CI_PROJECT_DIR/share/ci/install/cmake.sh && source $CI_PROJECT_DIR/share/ci/install/gcc.sh
+    - source $CI_PROJECT_DIR/share/ci/install/pypicongpu.sh   # python env + pytest
+    - $CI_PROJECT_DIR/share/picongpu/tests/KHI_growthRate/bin/ci.sh <test> <outdir> --keep-logs
+      # ci.sh: pic-create + pic-build + mpiexec -n 1 ... -s 3000 + validate
+    - cd $CI_PROJECT_DIR/lib/python/test/picongpu
+    - PIC_KHI_OPENPMD=<outdir>/simOutput/.../openpmd python3 -m pytest
+        end_to_end/test_khi_growthrate.py -v
+```
+
+- Cost: ~15–40 min of one CPU runner per run (weekly ≈ < 5 h/week).
+- Benefit: continuous physics regression signal for KHI + openPMD field
+  output + the validation pipeline itself; failures surface as a normal CI
+  job failure instead of an exit code in a manual log.
+- Cheaper alternative for the *pipeline logic only*: run the synthetic
+  `test_khi_growthrate.py` in the existing `pypicongpu` job (it is fast,
+  < 2 s) — this needs a one-line change in `share/ci/install/pypicongpu.sh`
+  and would also guard against the L7 class of environment regressions;
+  propose, don't wire.
+
+**Open question for the requester:** slow job on the main pipeline vs
+manual/periodic trigger (recommendation above: manual/periodic until the
+flow's load-bearing status is confirmed).
+
+## 7. CHANGELOG
+
+No `CHANGELOG.md` entry: the changelog is release-based (latest section
+0.8.0) with per-PR references and has no "unreleased" section; this
+exploratory branch has no PR number yet. Suggest adding an entry under the
+next release's "tools" bucket, e.g. "fix and modernise KHI growth-rate
+test tools (testsuite Math/Reader, openPMD-based validation)".
+
+## 8. Follow-ups (out of scope here)
+
+1. Add `etc/picongpu/picongpu.cfg` (openPMD field dump of `B`, period 10)
+   to `share/picongpu/tests/KHI_growthRate/`; decide fate of the
+   `--fields_energy` flag (L5/L6).
+2. Decide whether the KHI flow is load-bearing; if yes, adopt the proposed
+   CI job; if no, the legacy `setups/`+`Reader.dataReader/paramReader`
+   `.dat`/`.param` path can be retired (deletion was explicitly out of
+   scope for this task).
+3. Fix or document L1 (`searchParameter` `openpmd` → `UnboundLocalError`),
+   L2 (dead `-o` option), L3 (`eval`/`exec` + global config state),
+   L4 (`plot_2D` stub, `sys.exit(42)` swallowing).
+4. Report the broken openpmd-api 3.14 read path (L7) upstream if it
+   reproduces outside this container.
+5. Measure the real 3000-step runtime on a CI runner to firm up the cost
+   estimate in §6.1.

--- a/TASK-10-FINDINGS.md
+++ b/TASK-10-FINDINGS.md
@@ -144,7 +144,14 @@ headerless file -> getValue('Bx'): ValueError: The given Parameter could not be 
 i.e. the "simulation data" leg of the whole pipeline was dead for both
 possible on-disk formats. Fixed with `skiprows=1` (only reachable via
 headered files, since the sought parameter name is non-numeric, so no data
-row can ever be dropped).
+row can ever be dropped). The review (m1) found one residual edge case of
+that fix: `allParamsinFile` split the header line on single spaces, so the
+*last* column name kept its trailing newline (`"Bx\n" != "Bx"`) and a
+sought parameter that is the last header column was never found (a 2-column
+`step Bx` file made `getValue('Bx')` raise "could not be found" even on the
+fixed branch). Also fixed: the header is now split on whitespace
+(`split()`), with a 2-column-header regression test
+(`TestDataReaderTrailingColumn`).
 
 ### 3.2 Latent defects (documented, NOT fixed -- see scope note)
 

--- a/TASK-10-FINDINGS.md
+++ b/TASK-10-FINDINGS.md
@@ -130,7 +130,11 @@ ReadFiles(".dat", direction="/tmp").setDirection("/tmp")
 `CMAKEFlagReader.getAllSetups` (cmakeFlagReader.py:98) opened files without
 closing them. Under the repo's pytest regime (`filterwarnings = ["error"]`
 in `lib/python/pyproject.toml:88`) the resulting `ResourceWarning` fails any
-test exercising the parsers -- this is why the framework has zero tests.
+test exercising the parsers -- one of the reasons the framework has zero
+tests (the global config state, L3, and the missing fixtures are at least
+equally plausible). Both file-handle fixes have regression tests:
+`TestParamReader` for the paramReader side, `TestCMAKEFlagReader` for the
+cmakeFlagReader side (added in the rework, review m2).
 
 **B6 (additional, found & fixed) -- `DataReader.getValue` could not read the
 file format its own `allParamsinFile` defines.** `allParamsinFile` treats
@@ -214,8 +218,10 @@ fixed branch). Also fixed: the header is now split on whitespace
 - Zero automated tests, zero asserts; "pass" = one 20 % deviation check per
   case, reported via log file + exit code.
 - 6 real defects on the core computation/reader path (4 pre-existing named
-  + 2 found during this audit), all fixed on this branch with regression
-  tests; 7 documented latent/environmental defects.
+  + 2 found during this audit), all fixed on this branch, each with a
+  direct regression test (B5: `TestParamReader` for the paramReader handle,
+  `TestCMAKEFlagReader` for the cmakeFlagReader handle, the latter added in
+  the rework per review m2); 7 documented latent/environmental defects.
 - Untouched functionally since 2024-02 while the rest of the Python package
   was rewritten in 2025; the data source it parses (`fields_energy.dat`) is
   no longer produced by this checkout (L5), and the KHI input set produces

--- a/TASK-10-FINDINGS.md
+++ b/TASK-10-FINDINGS.md
@@ -1,9 +1,9 @@
-# TASK-10 — Audit of `lib/python/test/{testsuite,setups}`: what are they testing, what is their quality?
+# TASK-10 - Audit of `lib/python/test/{testsuite,setups}`: what are they testing, what is their quality?
 
-Branch: `task-10-testsuite-audit` (base `dev` @ b4e4ca5b2) · Date: 2026-08-29
+Branch: `task-10-testsuite-audit` (base `dev` @ b4e4ca5b2) - Date: 2026-08-29
 
-This document answers the two audit questions — *what are they testing?* and
-*what is their quality?* — with verified defects (reproducible commands),
+This document answers the two audit questions -- *what are they testing?* and
+*what is their quality?* -- with verified defects (reproducible commands),
 summarises the cleanup and modernisation commits on this branch, and gives a
 costed recommendation for CI integration.
 
@@ -11,7 +11,7 @@ costed recommendation for CI integration.
 
 ## 1. What are they?
 
-### 1.1 `lib/python/test/testsuite/` — a standalone post-simulation validation framework
+### 1.1 `lib/python/test/testsuite/` -- a standalone post-simulation validation framework
 
 Not a pytest suite. It is a self-contained **post-simulation validation
 framework** (origin 2022-12-09, last functional commit
@@ -19,22 +19,22 @@ framework** (origin 2022-12-09, last functional commit
 bachelor-thesis work per file headers). 21 Python files, ~3000 lines, ~75 KB
 (plus 4 files in `setups/`).
 
-Pipeline: `setups/<case>/main.py` (argparse CLI) →
-`testsuite._manager.run_testsuite()` →
+Pipeline: `setups/<case>/main.py` (argparse CLI) ->
+`testsuite._manager.run_testsuite()` ->
 `Reader` (crude parsers for `.param` preprocessor-style files, `.json`,
-`.dat` columns, `cmakeFlags`) → `config.theory(**parameter)` vs
+`.dat` columns, `cmakeFlags`) -> `config.theory(**parameter)` vs
 `config.simData(**parameter)` (the case's analytic theory and the simulated
-quantity) → `Math._manager._calculate` (deviation checks) →
-`Output` (`testresult.log` + matplotlib PNG) → `sys.exit(0/1/42)`.
+quantity) -> `Math._manager._calculate` (deviation checks) ->
+`Output` (`testresult.log` + matplotlib PNG) -> `sys.exit(0/1/42)`.
 
-### 1.2 `lib/python/test/setups/` — the two concrete cases
+### 1.2 `lib/python/test/setups/` -- the two concrete cases
 
-| Case | Title | Theory (units of ω_pe) | Simulated quantity | Acceptance |
+| Case | Title | Theory (units of omega_pe) | Simulated quantity | Acceptance |
 |---|---|---|---|---|
-| `ESKHI/` | KHI Growthrate (2D ESKHI) | `1/(√8·γ)` | growth rate of the `Bx` column of `fields_energy.dat` | 20 % |
-| `MI/` | KHI Growthrate (2D MI) | `v/(c·√γ)` with `v=√(1−1/γ²)·c` | growth rate of `Bx`, trimmed at the first local minimum | 20 % |
+| `ESKHI/` | KHI Growthrate (2D ESKHI) | `1/(sqrt(8)*gamma)` | growth rate of the `Bx` column of `fields_energy.dat` | 20 % |
+| `MI/` | KHI Growthrate (2D MI) | `v/(c*sqrt(gamma))` with `v=sqrt(1-1/gamma^2)*c` | growth rate of `Bx`, trimmed at the first local minimum | 20 % |
 
-Both measure the Kelvin–Helmholtz instability growth rate of the dominant
+Both measure the Kelvin-Helmholtz instability growth rate of the dominant
 magnetic field in a sub-relativistic shear-flow simulation
 ([Alves12], [Grismayer13], [Bussmann13]; see
 `share/picongpu/tests/KHI_growthRate/README.rst`) and pass if the simulated
@@ -44,30 +44,30 @@ growth rate is within 20 % of the analytic value.
 
 - **Not pytest**: no `test_*.py`/`*_test.py` files, no `assert`s.
   `cd lib/python && python -m pytest test/testsuite test/setups --collect-only -q`
-  → **`no tests collected`** (0 items).
+  -> **`no tests collected`** (0 items).
 - **Not imported by the `picongpu` package** (zero cross-imports; the package
   is installed from `lib/python/picongpu`, the framework lives in
   `lib/python/test/`).
-- **Not run by CI** (see §2).
+- **Not run by CI** (see section 2).
 - **Not duplicated** by the new `test/picongpu/` suite (2025 rewrite with
-  `quick/`/`compiling/`/`end_to_end/`): different purpose — physics
+  `quick/`/`compiling/`/`end_to_end/`): different purpose -- physics
   post-processing of real simulation output vs. package unit/integration
   tests.
 
-## 2. Are they tested in CI? — No
+## 2. Are they tested in CI? -- No
 
 CI is GitLab-based (`.gitlab-ci.yml` + `share/ci/`). Verified facts:
 
 1. The Python package jobs run only the new suite:
-   `share/ci/install/pypicongpu.sh:61-65` —
+   `share/ci/install/pypicongpu.sh:61-65` --
    `pip3 install -e lib/python[test]` then
    `cd lib/python/test/picongpu && python3 -m pytest quick/`;
    line 97: `python3 -m pytest compiling/ -v` (compile job only).
 2. `share/picongpu/tests/*` jobs (`share/ci/run_picongpu_tests.sh`) only
-   **compile** each test case and run a `picongpu --help` smoke test —
+   **compile** each test case and run a `picongpu --help` smoke test --
    **no simulation is ever executed in CI**.
 3. No CI script references KHI:
-   `grep -rn KHI .gitlab-ci.yml share/ci/` → no matches.
+   `grep -rn KHI .gitlab-ci.yml share/ci/` -> no matches.
 4. The sole consumer of the framework is
    `share/picongpu/tests/KHI_growthRate/bin/validate.sh:65-66`:
    `python $PICSRC/lib/python/test/setups/ESKHI/main.py -p ... -r ... -s ...`,
@@ -78,26 +78,26 @@ CI is GitLab-based (`.gitlab-ci.yml` + `share/ci/`). Verified facts:
 
 ## 3. Quality: verified defects (with evidence)
 
-All reproductions run in a clean shell; `PY=.../venvs/task-10/bin/python`,
-`T=lib/python/test` (worktree root).
+All reproductions run in a clean shell; `PY` = task venv python,
+`T = lib/python/test` (relative to the worktree root).
 
 ### 3.1 Computational bugs (fixed on this branch)
 
-**B1 — `Math/math.py::growthRate` returned half the growth rate.**
-The docstring formula `log(f(t_{k+1})/f(t_{k-1}))/(t_{k+1}−t_{k-1})` is a
-two-step centred difference that already yields Γ per unit time; the code
-multiplied by `0.5`, double-correcting the two-step span.
+**B1 - `Math/math.py::growthRate` returned half the growth rate.**
+The docstring formula `log(f(t_(k+1))/f(t_(k-1)))/(t_(k+1)-t_(k-1))` is a
+two-step centred difference that already yields Gamma per unit time; the
+code multiplied by `0.5`, double-correcting the two-step span.
 
 ```
 $ PY -c "import sys; sys.path.insert(0,'lib/python/test'); import numpy as np, testsuite.Math.math as m;
          t=np.arange(50.0); g=m.growthRate(2.0**t, t); print(np.mean(g), np.log(2))"
-0.346574 0.693147   # returned Γ/2 (ratio 0.5000 in both branches)
+0.346574 0.693147   # returned Gamma/2 (ratio 0.5000 in both branches)
 ```
 Skewed the verdict of *both* setups (sim rate measured at half value; a
-simulation matching theory would appear at ~−50 % deviation).
+simulation matching theory would appear at ~-50 % deviation).
 
-**B2 — `Math/deviation.py::getMinDifference` crashed on scalars, ambiguous on 2-D.**
-`np.abs(min(theory - simulation))` uses the built-in `min()` — although this
+**B2 - `Math/deviation.py::getMinDifference` crashed on scalars, ambiguous on 2-D.**
+`np.abs(min(theory - simulation))` uses the built-in `min()` -- although this
 function is part of the main pipeline (`Math/_manager.py:20 _calculate`).
 
 ```
@@ -105,11 +105,11 @@ getMinDifference(0.5, 0.5)            # TypeError: 'float' object is not iterabl
 getMinDifference(ones((2,3)), ...)    # ValueError: truth value of array ambiguous
 ```
 
-**B3 — `Math/deviation.py::getDifferenceInPercentage` docstring/code mismatch.**
-Docstring: `(theory − max(simulation)) / simulation * 100`; code:
-`(theory − max(simulation)) / theory * 100`. The code's semantics (relative
+**B3 - `Math/deviation.py::getDifferenceInPercentage` docstring/code mismatch.**
+Docstring: `(theory - max(simulation)) / simulation * 100`; code:
+`(theory - max(simulation)) / theory * 100`. The code's semantics (relative
 to theory) are the ones `getTestResult` and the acceptance range
-(`theory·(1±acceptance)`) rely on, so the docstring was corrected; also
+(`theory*(1+/-acceptance)`) rely on, so the docstring was corrected; also
 `max(simulation)` raised `TypeError` for scalar simulation values
 (`np.max` now).
 
@@ -117,7 +117,7 @@ to theory) are the ones `getTestResult` and the acceptance range
 getDifferenceInPercentage(2.0, [1.0, 1.5])  # code: 25.0, docstring formula: 33.33
 ```
 
-**B4 — `Reader/readFiles.py::setDirection` — `AttributeError`.**
+**B4 - `Reader/readFiles.py::setDirection` -- `AttributeError`.**
 Referenced `self.directiontype`; the attribute is `self._directiontype`.
 
 ```
@@ -125,14 +125,14 @@ ReadFiles(".dat", direction="/tmp").setDirection("/tmp")
 # AttributeError: 'ReadFiles' object has no attribute 'directiontype'
 ```
 
-**B5 (additional, found & fixed) — unclosed file handles.**
+**B5 (additional, found & fixed) -- unclosed file handles.**
 `ParamReader.paramInLine` (paramReader.py:193) and
 `CMAKEFlagReader.getAllSetups` (cmakeFlagReader.py:98) opened files without
 closing them. Under the repo's pytest regime (`filterwarnings = ["error"]`
 in `lib/python/pyproject.toml:88`) the resulting `ResourceWarning` fails any
-test exercising the parsers — this is why the framework has zero tests.
+test exercising the parsers -- this is why the framework has zero tests.
 
-**B6 (additional, found & fixed) — `DataReader.getValue` could not read the
+**B6 (additional, found & fixed) -- `DataReader.getValue` could not read the
 file format its own `allParamsinFile` defines.** `allParamsinFile` treats
 the first `.dat` line as the column-name header; `getValue` then read the
 same file with `np.loadtxt` (no `skiprows`), which dies on the header:
@@ -146,39 +146,40 @@ possible on-disk formats. Fixed with `skiprows=1` (only reachable via
 headered files, since the sought parameter name is non-numeric, so no data
 row can ever be dropped).
 
-### 3.2 Latent defects (documented, NOT fixed — see scope note)
+### 3.2 Latent defects (documented, NOT fixed -- see scope note)
 
-- **L1 — `Math/_searchData.py::searchParameter(directiontype="openpmd")`**
+- **L1 - `Math/_searchData.py::searchParameter(directiontype="openpmd")`**
   validates `"openpmd"` as a legal direction type but implements no branch
-  for it → `UnboundLocalError: cannot access local variable 'result'`. The
+  for it -> `UnboundLocalError: cannot access local variable 'result'`. The
   framework's advertised openPMD support was never written (no
-  `openPMDReader` exists). The modernisation (§5) supplies a real openPMD
-  path instead.
-- **L2 — `setups/ESKHI/main.py` and `setups/MI/main.py` parse `-o
+  `openPMDReader` exists). The modernisation (section 5) supplies a real
+  openPMD path instead.
+- **L2 - `setups/ESKHI/main.py` and `setups/MI/main.py` parse `-o
   <openPMD dir>` but never pass it to `run_testsuite`** (dead option).
-- **L3 — `_checkData.py` uses `eval("config."+name)` / `exec(...)`** to read
+- **L3 - `_checkData.py` uses `eval("config."+name)` / `exec(...)`** to read
   and *write* the global `config` module (e.g. `checkDirection` persists
   resolved directories into it). Stateful, fragile, and the reason any test
   of the framework must reset global config between tests.
-- **L4 — `Output/Viewer.py::plot_2D` is an empty stub**;
-  `_manager.py` blanket-catches `Exception` → `sys.exit(42)` (real errors
+- **L4 - `Output/Viewer.py::plot_2D` is an empty stub**;
+  `_manager.py` blanket-catches `Exception` -> `sys.exit(42)` (real errors
   surface only as `error.log` + exit code 42).
-- **L5 — the KHI flow's data source is gone.** `ci.sh` passes
+- **L5 - the KHI flow's data source is gone.** `ci.sh` passes
   `--fields_energy.period 10`, but no `fields_energy`/`fieldsEnergy`
   plugin/option exists anywhere in this checkout (only a stale reference in
   `src/tools/bin/plotNumericalHeating` docs and the same flag in
   `tests/FieldAbsorber`). If it is also gone upstream, the KHI flow has been
-  dead since the diagnostic was removed — the "load-bearing status
+  dead since the diagnostic was removed -- the "load-bearing status
   uncertain" flag is therefore well placed.
-- **L6 — the KHI input set has no openPMD diagnostics.**
+- **L6 - the KHI input set has no openPMD diagnostics.**
   `share/picongpu/tests/KHI_growthRate/` contains no
   `etc/picongpu/picongpu.cfg`, so the current test does not write openPMD
-  fields at all. The modernised openPMD check (§5) cannot run on it until a
-  `picongpu.cfg` with a field dump for `B` is added (follow-up, §7).
-- **L7 — environment: openpmd-api's read path is broken for Python 3.14 in
+  fields at all. The modernised openPMD check (section 5) cannot run on it
+  until a `picongpu.cfg` with a field dump for `B` is added (follow-up,
+  section 7).
+- **L7 - environment: openpmd-api's read path is broken for Python 3.14 in
   this container.** Write works (files verified correct byte-for-byte via
   h5py: correct groups, `time`/`dt` attributes, dataset contents), but
-  `load_chunk()` returns swapped/corrupted data — e.g. a 2-iteration scalar
+  `load_chunk()` returns swapped/corrupted data -- e.g. a 2-iteration scalar
   series reads back `[2.0, 1.0]` instead of `[1.0, 2.0]`, identical for
   openpmd-api 0.16.1 and 0.17.1.post4, h5 and BP backends, all read
   patterns. The project targets Python `>=3.11,<3.14`
@@ -211,7 +212,7 @@ row can ever be dropped).
 - Untouched functionally since 2024-02 while the rest of the Python package
   was rewritten in 2025; the data source it parses (`fields_energy.dat`) is
   no longer produced by this checkout (L5), and the KHI input set produces
-  no openPMD fields (L6) — the flow is likely already non-functional end to
+  no openPMD fields (L6) -- the flow is likely already non-functional end to
   end.
 
 ## 4. Quick cleanup (commits b4e4ca5b2..997037074)
@@ -234,16 +235,16 @@ Gate: `pytest quick/` went from `174 passed, 2 xfailed, 1 xpassed` to
 `lib/python/test/picongpu/end_to_end/khi_growthrate.py` re-expresses the
 ESKHI validation as openPMD-consuming checks:
 
-- `bx_amplitude_per_iteration(series)` — f(t) = max|Bx| per iteration from
+- `bx_amplitude_per_iteration(series)` -- f(t) = max|Bx| per iteration from
   the openPMD series (`meshes["B"]["x"]`, the same access pattern as
   `end_to_end/compare_particles.py::read_fields`); this replaces the
   `fields_energy.dat` `Bx` column.
-- `times_omega_pe(series, density_si, gamma)` — openPMD `time` (SI) ×
-  relativistic plasma frequency; replaces the `step` column ×
+- `times_omega_pe(series, density_si, gamma)` -- openPMD `time` (SI) times
+  relativistic plasma frequency; replaces the `step` column times
   `DELTA_T_SI` from `.dat`/`.param`.
-- `eskhi_growthrate_theory(gamma)` = `1/(√8·γ)` (same as
+- `eskhi_growthrate_theory(gamma)` = `1/(sqrt(8)*gamma)` (same as
   `setups/ESKHI/config.py::theory`).
-- `validate_eskhi_growthrate(path, gamma, density_si, acceptance=0.2)` —
+- `validate_eskhi_growthrate(path, gamma, density_si, acceptance=0.2)` --
   **reuses the corrected `testsuite.Math` (`growthRate`,
   `getMinDifference`, `getDifferenceInPercentage`, `getTestResult`) as the
   reference**, so the new path and the legacy path share one computation.
@@ -251,23 +252,23 @@ ESKHI validation as openPMD-consuming checks:
 `lib/python/test/picongpu/end_to_end/test_khi_growthrate.py` (auto-marked
 `slow`+`end_to_end` by `test/picongpu/conftest.py`):
 
-- synthetic openPMD series whose Bx grows with the analytic esKHI rate →
+- synthetic openPMD series whose Bx grows with the analytic esKHI rate ->
   asserts the pipeline recovers the analytic rate and the verdict is
-  `passed` (exercises openPMD read → growth rate → analytic comparison);
-- `test_real_khi_run_validation` — validates a real KHI openPMD output
+  `passed` (exercises openPMD read -> growth rate -> analytic comparison);
+- `test_real_khi_run_validation` -- validates a real KHI openPMD output
   provided via `PIC_KHI_OPENPMD` (defaults for `PIC_KHI_GAMMA`/
-  `PIC_KHI_DENSITY_SI` taken from the KHI test's `.param` files: γ=1.021,
+  `PIC_KHI_DENSITY_SI` taken from the KHI test's `.param` files: gamma=1.021,
   n=1e25).
 
 Verification status: the full pipeline was verified end-to-end here by
 running `validate_eskhi_growthrate` over the synthetic series with the
 openpmd read layer substituted by an h5py-backed equivalent (files verified
-correct on disk) — theory `0.22097086912079605` vs simulation
+correct on disk) -- theory `0.22097086912079605` vs simulation
 `0.22097086912079608`, verdict `True`. The only part not executed in this
 container is the literal `openpmd_api.load_chunk()` call, because of L7
 (openpmd-api's 3.14 read path is broken here); the tests therefore
 self-check the read path and skip with a clear message in broken
-environments, running on CI's Python 3.11–3.13.
+environments, running on CI's Python 3.11-3.13.
 
 Nothing was deleted: the legacy `.dat`/`.param` path (`setups/`,
 `Reader/dataReader`, `Reader/paramReader`) is untouched and remains the
@@ -278,21 +279,21 @@ and the flow's future is decided.
 
 **Question:** should these validations run regularly as part of the test
 suite / CI? They are physics post-processing of a *real* 3000-step
-simulation — `slow`/`end_to_end` class, not unit tests.
+simulation -- `slow`/`end_to_end` class, not unit tests.
 
 ### 6.1 Cost of one run (CPU runner, single config)
 
 | Step | Cost estimate | Notes |
 |---|---|---|
-| `pic-create` + `pic-build` (KHI only, 1 config) | ~10–20 min | as done by existing compile jobs; single case, `PIC_CI_COMPILE`-style flags |
-| `mpiexec -n 1 picongpu -g 192 512 12 -s 3000` | ~5–20 min (unmeasured) | 1.18 M cells, 3000 steps, 1 rank on a cpuonly runner; **no in-repo benchmark exists — CI never runs any simulation**; to be measured on a real runner |
-| Validation (openPMD read + pytest) | < 1 min | 300 iterations × Bx(192×512×12) |
-| **Total** | **~15–40 min per job** | one cpuonly runner slot |
+| `pic-create` + `pic-build` (KHI only, 1 config) | ~10-20 min | as done by existing compile jobs; single case, `PIC_CI_COMPILE`-style flags |
+| `mpiexec -n 1 picongpu -g 192 512 12 -s 3000` | ~5-20 min (unmeasured) | 1.18 M cells, 3000 steps, 1 rank on a cpuonly runner; **no in-repo benchmark exists -- CI never runs any simulation**; to be measured on a real runner |
+| Validation (openPMD read + pytest) | < 1 min | 300 iterations x Bx(192x512x12) |
+| **Total** | **~15-40 min per job** | one cpuonly runner slot |
 
 ### 6.2 Pre-conditions (not met today)
 
 1. The KHI input set writes **no openPMD fields** (L6): a
-   `etc/picongpu/picongpu.cfg` with a field dump of `B` (period ≈ 10) must
+   `etc/picongpu/picongpu.cfg` with a field dump of `B` (period ~10) must
    be added to `share/picongpu/tests/KHI_growthRate/` before the
    modernised check can consume anything.
 2. The legacy `--fields_energy` flag no longer resolves to a plugin in this
@@ -300,10 +301,10 @@ simulation — `slow`/`end_to_end` class, not unit tests.
 3. A decision is needed on whether the KHI growth-rate flow is still
    load-bearing (requester: uncertain).
 
-### 6.3 Recommendation (proposal only — not wired into CI)
+### 6.3 Recommendation (proposal only -- not wired into CI)
 
 Do **not** add this to the default MR pipeline: it would be the first
-simulation run ever executed in CI, it needs pre-conditions 1–2 to be met
+simulation run ever executed in CI, it needs pre-conditions 1-2 to be met
 first, and its load-bearing status is unconfirmed. Instead:
 
 **Proposed job** (to add once pre-conditions are met and the requester
@@ -317,7 +318,7 @@ khi-growthrate-validation:
   image: <same alpaka-ci image as .base_pypicongpu_quick_test>
   tags: [cpuonly, x86_64]
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'   # or: - if: '$CI_COMMIT_BRANCH == "dev"' + when: manual
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'   # or: manual trigger on a branch
   script:
     - source $CI_PROJECT_DIR/share/ci/install/cmake.sh && source $CI_PROJECT_DIR/share/ci/install/gcc.sh
     - source $CI_PROJECT_DIR/share/ci/install/pypicongpu.sh   # python env + pytest
@@ -328,13 +329,13 @@ khi-growthrate-validation:
         end_to_end/test_khi_growthrate.py -v
 ```
 
-- Cost: ~15–40 min of one CPU runner per run (weekly ≈ < 5 h/week).
+- Cost: ~15-40 min of one CPU runner per run (weekly = < 5 h/week).
 - Benefit: continuous physics regression signal for KHI + openPMD field
   output + the validation pipeline itself; failures surface as a normal CI
   job failure instead of an exit code in a manual log.
 - Cheaper alternative for the *pipeline logic only*: run the synthetic
   `test_khi_growthrate.py` in the existing `pypicongpu` job (it is fast,
-  < 2 s) — this needs a one-line change in `share/ci/install/pypicongpu.sh`
+  < 2 s) -- this needs a one-line change in `share/ci/install/pypicongpu.sh`
   and would also guard against the L7 class of environment regressions;
   propose, don't wire.
 
@@ -359,10 +360,10 @@ test tools (testsuite Math/Reader, openPMD-based validation)".
    CI job; if no, the legacy `setups/`+`Reader.dataReader/paramReader`
    `.dat`/`.param` path can be retired (deletion was explicitly out of
    scope for this task).
-3. Fix or document L1 (`searchParameter` `openpmd` → `UnboundLocalError`),
+3. Fix or document L1 (`searchParameter` `openpmd` -> `UnboundLocalError`),
    L2 (dead `-o` option), L3 (`eval`/`exec` + global config state),
    L4 (`plot_2D` stub, `sys.exit(42)` swallowing).
 4. Report the broken openpmd-api 3.14 read path (L7) upstream if it
    reproduces outside this container.
 5. Measure the real 3000-step runtime on a CI runner to firm up the cost
-   estimate in §6.1.
+   estimate in section 6.1.

--- a/TASK-10-RESPONSE.md
+++ b/TASK-10-RESPONSE.md
@@ -1,0 +1,113 @@
+# TASK-10 - Rework response to review (TASK-10-REVIEW.md)
+
+Branch: `task-10-testsuite-audit` (review tip `1a996c8be`) - 2026-08-31
+Verdict addressed: APPROVE (0 critical / 0 major / 3 minor / 6 nits).
+
+Every claim below was re-verified against the branch code in this container
+before acting. All changes are new commits on top of the review commit;
+nothing is deleted; `TASK-10-REVIEW.md` is untouched.
+
+## Disposition per finding
+
+| ID | Disposition | Commit |
+|----|-------------|--------|
+| m1 | fixed | `762c41b9b` |
+| m2 | fixed | `2ea8e370d` |
+| m3 | fixed | `77ceb3a79` |
+| n1 | fixed | `624156fd4` |
+| n2 | fixed | `624156fd4` |
+| n3 | fixed | `624156fd4` |
+| n4 | fixed | `77ceb3a79` |
+| n5 | fixed | `a52ce40db` |
+| n6 | fixed | `5707a3576` |
+| -  | gate fix (inherited red pre-commit) | `2b33e490f` |
+
+## Detail and evidence
+
+- **m1 (fixed)** - `allParamsinFile` now splits the header line on
+  whitespace (`split()`), so the last column no longer keeps its trailing
+  newline. Reproduced first: on the review tip a 2-column `step Bx` file
+  gave `getDatwithParam('Bx') == []` and `getValue('Bx')` raised "could not
+  be found"; a 3-column `step Bx By` file worked. Added
+  `TestDataReaderTrailingColumn` (2-column header): the three tests fail on
+  the pre-fix code and pass after. B6 in the findings doc now records the
+  residual edge case and its fix.
+
+- **m2 (fixed)** - added `TestCMAKEFlagReader` (getAllSetups / usedSetup /
+  getValue on a fixture file) so the B5 fix in `cmakeFlagReader.py` has a
+  direct regression test; `gc.collect()` after `getAllSetups()` forces an
+  unclosed handle to raise its ResourceWarning under `filterwarnings=error`.
+  Verified: reverting the B5 `with open` makes `test_get_all_setups` and
+  `test_get_value` fail with a ResourceWarning. The B5 finding and the
+  quality summary are reworded: the "this is why the framework has zero
+  tests" causal claim is softened, and all six fixes now have a direct
+  regression test.
+
+- **m3 (fixed)** - the proposed job no longer invokes `ci.sh` (dead
+  `--fields_energy.period 10` at ci.sh:120, dead `validate.sh` call at
+  ci.sh:124). It now inlines the runnable steps (pic-create + pic-build +
+  `mpiexec ... -s 3000` without the dead flag) and validates with the
+  openPMD pytest step from this branch. Added the ci.sh/validate.sh fix as
+  an explicit pre-condition (now #3). Both line numbers and the dead flag
+  were re-confirmed by reading the current `ci.sh`.
+
+- **n1 (fixed)** - `validate.sh` main.py call is at :67 (not 65-66);
+  `filterwarnings = ["error"]` is at `lib/python/pyproject.toml:92` (not
+  :88). Both confirmed by reading the files.
+
+- **n2 (fixed)** - sign corrected: `getDifferenceInPercentage(Gamma,
+  Gamma/2)` = +50, not -50. Verified: the function returns 50.0 for
+  (1.0, 0.5). The B1 narrative now reads "~+50 % deviation ... -> fail".
+
+- **n3 (fixed)** - the 21 `testsuite/*.py` files are 2630 lines (not
+  ~3000); the ~75 KB figure (74 504 bytes) was already accurate and is kept.
+  Counted with `find ... | xargs wc -l`.
+
+- **n4 (fixed)** - one 15-40 min job per week is < 1 h/week, not < 5 h/week.
+  Cost bullet corrected to "(weekly = < 1 h/week of one CPU runner)".
+
+- **n5 (fixed)** - `times_omega_pe` now reads `time * time_unit_SI`.
+  Verified: openpmd-api 0.17.1 exposes `time_unit_SI` and reports the
+  standard default 1.0 when the attribute is absent (so PIConGPU output and
+  the synthetic tests are unchanged); an explicit `timeUnitSI=2.0` scales
+  the result as expected.
+
+- **n6 (fixed)** - added `test_validation_fails_below_theory`: a series
+  growing at half the analytic rate must fail the 20 % acceptance. Verified
+  the logic standalone (openpmd read path is self-skipping in this
+  container, as the positive tests are): 50 %-of-theory series -> 50.0 %
+  deviation -> `result False`. The test collects cleanly (5 tests in the
+  file, was 4).
+
+## Gate fix (inherited, not a review finding)
+
+`pre-commit run --all-files` was already failing at the review commit
+`1a996c8be`: the review team's `TASK-10-REVIEW.md` contains non-ASCII math
+notation (274 non-ASCII bytes), which trips `require-ascii`. The rework
+rules forbid modifying that file, so instead of editing it I added it to
+the hook's documented `exclude` (the same mechanism the config already uses
+for CHANGELOG.md etc.) in `2b33e490f`. No other file needed an exclusion.
+
+## Deliberately not done (with rationale)
+
+- **Wiring the synthetic test into the `pypicongpu` CI job** (review
+  section 6, item 4, "one-line pypicongpu.sh change"): not applied. The
+  task is an exploratory investigation with an explicit "propose, don't
+  wire" scope, and whether/where KHI validation runs in CI is the open
+  question left to the requester. Changing `share/ci/install/pypicongpu.sh`
+  would alter CI behaviour for every MR, beyond the light-rework mandate.
+  Instead the findings doc now states the exact one-line change, why the
+  auto-applied `slow`/`end_to_end` markers do not block it (no `-m` filter
+  is active there), and that the real-run test self-skips without
+  `PIC_KHI_OPENPMD`, so it is trivial for the requester to adopt.
+
+## Final gate results (at final tip)
+
+- `cd lib/python/test/picongpu && python -m pytest quick/ -q`
+  -> `207 passed, 2 xfailed, 1 xpassed, 3499 subtests passed`
+  (baseline `201 passed, 2 xfailed, 1 xpassed` + 6 new quick tests:
+  3 trailing-column + 3 CMAKEFlagReader).
+- `pre-commit run --all-files` -> all hooks passed (21 Passed, 0 Failed).
+- compiling/ and end_to_end/ marker tests were not executed (per task
+  constraint); the two new end_to_end-related changes were verified by
+  standalone logic checks and collection only.

--- a/TASK-10-REVIEW.md
+++ b/TASK-10-REVIEW.md
@@ -1,0 +1,130 @@
+# Review — Task 10: Audit `lib/python/test/{testsuite,setups}` (cleanup + openPMD modernisation draft)
+
+- **Branch:** `task-10-testsuite-audit` (tip `ce5a79568`, base `dev` @ `b4e4ca5b2`)
+- **Reviewed:** 2026-08-31 · **Scope:** 11 commits, 15 files, +903/−47
+- **Verdict:** APPROVE
+  (audit is accurate on every spot-checked claim; cleanup is safe and verified; the modernisation draft works within its honestly-documented scope; only minor issues remain.)
+
+## 1. Summary
+
+The branch audits the standalone KHI post-simulation validation framework (`testsuite/` + `setups/`), fixes six real defects in it (4 pre-named + 2 found during the audit) plus three stale docs, adds 27 pytest unit tests under `quick/testsuite/`, drafts an openPMD-based re-expression of the ESKHI validation (`end_to_end/khi_growthrate.py` + `test_khi_growthrate.py`), and gives a costed manual/weekly CI proposal. I re-ran the gate (`201 passed, 2 xfailed, 1 xpassed`, baseline `174 passed, 2 xfailed, 1 xpassed` — both reproduced exactly in this container) and independently reproduced every bug/defect claim (B1–B6, L1–L7) against the dev code, including the openpmd-api 3.14 read-path breakage (on-disk file verified correct via h5py, `load_chunk` returns swapped data). The audit is unusually well-evidenced and I found no materially wrong statement — only line-number drift, a sign error, one over-claimed "with regression tests" sentence, and one undocumented residual edge case of the `DataReader` fix. The modernisation reuses the corrected `testsuite.Math` as the reference (verified: synthetic pipeline recovers the analytic rate to ~1e-16 relative error, verdict `True`), self-skips in broken openpmd environments, and deletes nothing, as the task required. The CI recommendation (manual/weekly, not per-MR) is well argued; its proposed job script should state explicitly that `ci.sh` must first be fixed (it still carries the dead `--fields_energy.period 10` flag).
+
+Most important issues, one line each:
+
+1. **m1** — the B6 `skiprows=1` fix does not cover `.dat` files whose header's *last* column is the sought parameter (trailing-newline quirk in `allParamsinFile`), and the findings doc presents B6 as fully fixed without listing this residual limitation.
+2. **m3** — the proposed CI job invokes `ci.sh`, which contains the dead `--fields_energy.period 10` flag and calls the dead legacy `validate.sh`; "fix ci.sh/validate.sh" is missing from the §6.2 pre-conditions, so the job as written would fail.
+3. **m2** — "all fixed on this branch with regression tests" is overclaimed: the `cmakeFlagReader` file-handle fix (B5) has no test at all.
+
+## 2. Findings
+
+### 2.1 Critical
+
+None found.
+
+### 2.2 Major
+
+None found.
+
+### 2.3 Minor
+
+- **m1** — `lib/python/test/testsuite/Reader/dataReader.py:102` (`allParamsinFile`) — the B6 fix (commit `528666828`, `skiprows=1` at lines 212/214/218/228) is incomplete for one real input shape: `allParamsinFile` splits the header line with `split(" ")`, so the **last** column name keeps its trailing newline (`"Bx\n"` ≠ `"Bx"`); when the sought parameter is the last header column, `getDatwithParam` finds nothing and `getValue` raises `ValueError: The given Parameter could not be found` — even on this branch. The author's own unit test works around it (`quick/testsuite/test_reader.py:78-79`: "Bx must not be the last header column"), but TASK-10-FINDINGS.md §3.1 (B6) presents the pipeline as "fixed with `skiprows=1`" and the residual limitation appears in neither B6 nor the L1–L7 latent-defect list. For the ESKHI flow this is material: whether `Bx` is the last column of a real `fields_energy.dat` header decides whether the "fixed" legacy path works at all.
+  - *Evidence:* repro in `/tmp/opencode/review-10/verify_b6.py`: branch code, 3-column header `step Bx By` → `Bx = [1. 2. 4. 8.]` OK; 2-column header `step Bx` → `ValueError: The given Parameter could not be found` (dev fails both).
+  - *Suggested fix:* one-liner — in `allParamsinFile`, `line = fi.readlines()[0].split()` (whitespace split, strips the newline) — and add a regression test with a 2-column header (`"step Bx\n"`). Also add the limitation (or the fix) to the findings doc.
+
+- **m2** — `TASK-10-FINDINGS.md:210-211` (§3.4 "all fixed on this branch with regression tests") and §4 table — overclaim. The B5 fix (commit `7e5501907`) touched two files: `paramReader.py:193` (exercised incidentally by `TestParamReader::test_get_value` → `getValue` → `paramInLine`) and `cmakeFlagReader.py:98` (`getAllSetups`) — the latter has **no** test; there is no `CMAKEFlagReader` test in `quick/testsuite/`. The paramReader side is also only covered *incidentally*: a reverted unclosed `open()` would surface as a GC-time `ResourceWarning`, which under `filterwarnings=error` is not a deterministic per-test failure. Related: §3.1 (B5) "this is why the framework has zero tests" is causal over-attribution — the global `config` state (L3) and missing fixtures are at least equally plausible; fine as a hypothesis, not as a stated cause.
+  - *Evidence:* `grep -rn "cmakeFlag" lib/python/test/picongpu/quick/` → no matches; `git show 7e5501907 --stat` → both files.
+  - *Suggested fix:* add a small `TestCMAKEFlagReader` (fixture `cmakeFlags` file, assert `getAllSetups()` returns the flags, and that it runs clean under the existing `filterwarnings=error` regime); soften §3.4 to "five of six with direct regression tests; the cmakeFlagReader fix is covered by [X]" or add the test.
+
+- **m3** — `TASK-10-FINDINGS.md:310-329` (§6.3 proposed job) — the proposed `khi-growthrate-validation` job runs `KHI_growthRate/bin/ci.sh`, which (a) passes the dead flag `--fields_energy.period 10` (`ci.sh:120`; no such plugin/option exists in this checkout — the audit's own L5) and (b) ends with `validate.sh` running the legacy `.dat`/ESKHI path, which is not functional for the reasons in B6/L5. §6.2's pre-conditions list the `picongpu.cfg` field dump and the load-bearing decision, but not "fix `ci.sh`/`validate.sh` (drop the dead flag; replace the `validate.sh` call with the new openPMD pytest step)". As written, the proposed job would fail at the simulation step regardless of the pre-conditions.
+  - *Evidence:* `share/picongpu/tests/KHI_growthRate/bin/ci.sh:120` (`--fields_energy.period 10`), `:124` (calls `validate.sh`); grep for `fields_energy` in `src/` finds only stale doc references.
+  - *Suggested fix:* add item 4 to §6.2: "replace `ci.sh`'s `--fields_energy.period 10` and its `validate.sh` invocation (dead, see L5/B6) with the openPMD run + `pytest end_to_end/test_khi_growthrate.py` step"; optionally show the corrected 5-line script.
+
+### 2.4 Nits
+
+- **n1** — `TASK-10-FINDINGS.md:73,131` — line-number drift: the `main.py` call in `validate.sh` is at **:67**, not 65-66 (the task file's "65" was copied through); `filterwarnings = ["error"]` is at `lib/python/pyproject.toml:92`, not :88.
+  - *Suggested fix:* correct the two references (or drop the line numbers).
+
+- **n2** — `TASK-10-FINDINGS.md:97` (B1 narrative) — "a simulation matching theory would appear at ~-50 % deviation" has the wrong sign: with the 0.5 bug, `getDifferenceInPercentage(theory, Γ/2) = (Γ − Γ/2)/Γ·100 = +50`.
+  - *Evidence:* `getDifferenceInPercentage(1.0, 0.5)` → `50.0`.
+  - *Suggested fix:* write "~+50 % (i.e. |deviation| 50 % > 20 % acceptance → fail)".
+
+- **n3** — `TASK-10-FINDINGS.md:19` — "~3000 lines" is ~14 % high: the 21 `.py` files total 2630 lines (the ~75 KB figure is accurate: 74 504 bytes).
+  - *Suggested fix:* "~2600 lines".
+
+- **n4** — `TASK-10-FINDINGS.md:332` — "(weekly = < 5 h/week)" is inconsistent with one 15-40 min job per week (≤ ~0.7 h/week); 5 h/week would imply ~8 runs/week.
+  - *Suggested fix:* "weekly = < 1 h/week of one CPU runner".
+
+- **n5** — `lib/python/test/picongpu/end_to_end/khi_growthrate.py:56` — `times_omega_pe` uses the raw openPMD `time` attribute without applying `timeUnitSI`. PIConGPU currently writes `timeUnitSI = 1.0` (verified in an on-disk dump), so this works today, but the unit-robust form is `time * iteration.time_unit_SI`.
+  - *Suggested fix:* `t_si = float(it.time) * float(it.time_unit_SI)` (or document the assumption next to the call).
+
+- **n6** — `lib/python/test/picongpu/end_to_end/test_khi_growthrate.py:85-123` — the synthetic suite only asserts the positive verdict. A one-line negative case (write a series growing at e.g. 50 % of the analytic rate and assert `result["result"] is False`) would guard the verdict/acceptance wiring, not just the rate recovery.
+  - *Evidence:* logic check in `/tmp/opencode/review-10` (50 %-of-theory series → diff 50.0 % → `result False`), so this is a coverage suggestion, not a logic bug.
+
+## 3. Requirement traceability
+
+| # | Requirement (from task file) | Status | Where / note |
+|---|---|---|---|
+| 1 | Report answering "what do they test" + "quality", with concrete defects | met | TASK-10-FINDINGS.md §1-§3. ~15 specific claims spot-checked against dev (B1–B6 repros, L1–L7, CI scripts, docs, git history, .param values) — all accurate apart from nits n1-n4 |
+| 2 | Cleanup: fix `growthRate` factor-2 | met | dev returns ln2/2 (0.346574) for 2^t; branch returns 0.693147; regression test `test_exponential_no_half_factor` |
+| 3 | Cleanup: fix `getMinDifference` | met | dev: `TypeError` on scalars; branch: `0.0`; 1-D behaviour unchanged; regression test present |
+| 4 | Cleanup: fix `getDifferenceInPercentage` | met | docstring aligned to the code's theory-relative semantics (the ones `getTestResult`/acceptance rely on — verified against `deviation.py:196-239`); `np.max` fixes scalar `simulation`; test present |
+| 5 | Cleanup: fix `setDirection` | met | dev: `AttributeError: ... directiontype`; branch: works; regression test present |
+| 6 | Cleanup: fix the three stale docs | met | all three claims verified against dev docs and the real files; the new `usage.rst` `--delete` statement is accurate (it is a flag of `ci.sh:42,60-62,127-129`, not `main.py`) |
+| 7 | Cleanup: minimal unit tests for `Math/` + `Reader/` into `quick/` | met | 27 tests (12 math + 15 reader), green under the repo's `filterwarnings = ["error"]` regime; `conftest.py` resets the global template-config state (L3) between tests |
+| 8 | Do not delete anything (KHI flow fate uncertain) | met | diff contains no deletions; legacy `.dat`/`.param` path retained as fallback |
+| 9 | Modernisation draft: pytest checks consuming openPMD via openpmd-api, `Math` kept as reference | met (draft) | `end_to_end/khi_growthrate.py` reuses corrected `testsuite.Math` (verified); access pattern matches `compare_particles.py::read_fields`; ESKHI-only scope is documented and justified (ESKHI is the only setup the KHI flow's `validate.sh` actually runs); self-skip on broken openpmd read path; `openpmd-api` is a main package dep, so no new dep needed |
+| 10 | Modernisation verification: "reproduces the (corrected) analytic comparison on an available KHI run" | partial | no real KHI run exists in this container and the KHI input set writes no openPMD fields (L5/L6 — coordinator-confirmed prerequisites). Verified instead on a synthetic series with an h5py-backed read: theory 0.22097086912079605 vs simulation rel. diff ~1e-16, verdict True (matches the doc's numbers); independently reproduced. The "only unexecuted part is the literal `load_chunk()`" statement is accurate |
+| 11 | CI integration investigation: costed proposal or documented reason | met | §6: cost table (1.18 M cells = 192·512·12, correct), pre-conditions, manual/weekly recommendation with argued reasons, cheaper alternative (synthetic test in the existing `pypicongpu` job) identified and proposed. Gap: m3 |
+| 12 | Semantically coherent commits | met | 11 focused commits, one concern each (bug fix / doc / tests / modernisation / findings / pre-commit) |
+| 13 | No C++ changes | met | diff touches only `lib/python/test/**` and `docs/source/testing/**` |
+
+## 4. Claim verification (author artifact)
+
+| Claim (from TASK-10-FINDINGS.md / author report) | Re-verified? | Result / delta |
+|---|---|---|
+| Test gate: "201 passed, 2 xfailed, 1 xpassed" (baseline "174 passed, 2 xfailed, 1 xpassed") | yes | **Exact match.** Branch: `201 passed, 2 xfailed, 1 xpassed, 3499 subtests passed`; baseline (dev tree extracted to scratch, same venv): `174 passed, 2 xfailed, 1 xpassed`. Δ = the 27 new tests, nothing else changed. (Note: the xpass is `test_validate_rocrate` and is a pre-existing environment quirk — see FYI — identical in dev.) |
+| B1 growthRate returned Γ/2, docstring has no 0.5, "0.346574 vs 0.693147" | yes | Reproduced on dev (0.346574); branch returns 0.693147. 0.5 present since the first commit `840a48dba` alongside the docstring |
+| B2 `getMinDifference` `TypeError` on scalars, used in `Math/_manager.py:20` | yes | Reproduced; `_manager.py:20` is exactly `dv.getMinDifference(...)` |
+| B3 docstring/code mismatch (`/ simulation` vs `/ theory`) | yes | dev docstring `deviation.py:149` vs code `:173`; code semantics are the ones `getTestResult` relies on, so fixing the docstring was the right choice |
+| B4 `setDirection` → `AttributeError` on `self.directiontype` | yes | Reproduced on dev (`readFiles.py:94` vs attribute `_directiontype` at `:69`) |
+| B5 unclosed handles at `paramReader.py:193`, `cmakeFlagReader.py:98`; "this is why the framework has zero tests" | yes (lines + warning) / partial (causal claim) | Both line numbers exact; `ResourceWarning: unclosed file` reproduced on dev under warnings-as-errors. Causal "why zero tests" is over-attribution (m2) |
+| B6 `getValue` dead for headered ("could not convert string 'step'") and headerless ("could not be found") files; fixed with `skiprows=1` | yes / with residual edge case | Both dev repros match exactly; fix verified for 3-column headers; **not** fixed for last-column headers (m1) |
+| L1 `searchParameter(directiontype="openpmd")` → `UnboundLocalError`; no openPMDReader exists | yes | `_searchData.py:47` accepts "openpmd", no branch implements it, `result` unbound at `:86`; Reader/ contains no openPMD reader |
+| L2 `-o` parsed but never passed in both `main.py`s | yes | ESKHI `main.py:56-64` vs `:79-84`; MI `main.py:69` vs `:100-105` |
+| L3 `eval`/`exec` in `_checkData.py` (exec at :115), persists dirs into global config | yes | `eval` at :94/:148/:190, `exec` at :115 — line exact |
+| L4 `plot_2D` empty stub; blanket `except` → `sys.exit(42)` | yes | `Viewer.py:144-146` (`pass`); `_manager.py:115-117` |
+| L5 no `fields_energy` plugin in this checkout; only stale refs (plotNumericalHeating docs, FieldAbsorber) | yes (scoped) | grep of `src/` confirms only `src/tools/bin/plotNumericalHeating:27,133` and `tests/FieldAbsorber` cfgs. (This checkout has no C++ sources at all — see FYI; the doc correctly says "in this checkout") |
+| L6 KHI input set has no `picongpu.cfg` / no openPMD fields | yes | `share/picongpu/tests/KHI_growthRate/` contains only `bin/`, `cmakeFlags`, `include/`, `README.rst` |
+| L7 openpmd-api 3.14 read path broken here (write OK, on-disk correct, read returns `[2.0, 1.0]`) | yes | Independently reproduced with openpmd-api 0.17.1 on Python 3.14.5: read-back `[2.0, 1.0]`; h5py dump of the same file shows correct per-iteration data and `time`/`dt`/`timeUnitSI` attrs |
+| end_to_end tests auto-marked `slow`+`end_to_end` by `conftest.py` | yes | `test/picongpu/conftest.py:27-28`; all 4 tests collect and skip here (3 via the round-trip self-check, 1 via missing `PIC_KHI_OPENPMD`) |
+| Pipeline "verified end-to-end ... theory 0.22097086912079605 vs simulation 0.22097086912079608, verdict True" via h5py-backed read | yes | Independently reproduced (h5py read of the same synthetic series, same `testsuite.Math` calls): rel. diff ~6e-16, `getTestResult` True |
+| CI facts: `pypicongpu.sh:61-65`/`:97`; no KHI in `.gitlab-ci.yml`/`share/ci/`; PIC jobs compile-only + `--help` smoke; sole consumer `validate.sh` (line "65-66"); collect-only → 0 items; no `testpaths` | yes (one line-number drift) | All verified; the `main.py` call is at `validate.sh:67` (n1); `pytest test/testsuite test/setups --collect-only` → "no tests collected" |
+| "21 Python files, ~3000 lines, ~75 KB"; origin 2022-12-09; last functional commit `0e3f64f3f` 2024-02-28 | yes (line count loose) | 21 files ✓; 74 504 bytes ✓; 2630 lines (n3); `840a48dba` 2022-12-09 ✓; post-`0e3f64f3f` commits are copyright/requirements/pre-commit only ✓ |
+| KHI defaults gamma=1.021, n=1e25 (new real-run test) | yes | `particle.param:38` `PARAM_GAMMA 1.021`; `simulation.param:74` `BASE_DENSITY_SI = 1.e25` |
+| CHANGELOG is release-based (latest 0.8.0), no unreleased section → no entry added | yes | `CHANGELOG.md` starts at `0.8.0` with per-PR refs; no Unreleased bucket |
+| pre-commit / ruff pass (final commits), findings doc ASCII-only | yes | ruff 0.12.10 (pinned rev): `ruff check --ignore E721` and `ruff format --line-length 120 --check` clean on all 11 touched/new Python files; findings doc passes an ASCII scan |
+
+## 5. Design discussion
+
+- **Reuse of `testsuite.Math` as the reference in the modernised check is the right call.** One computation path (corrected `growthRate` + deviation helpers) shared by legacy and new code means the two cannot silently diverge, and the B1-B3 fixes are what make the new check meaningful. The cost is that importing the pure math pulls in `_checkData`'s `eval`/`exec` global-config machinery (L3) transitively; since `acceptance` is always passed explicitly, no global state is actually read on the happy path — but a stray top-level `config.py` on `sys.path` *would* be picked up by `_checkData` and could override explicit parameters ("the value from config.py is always taken first"). Acceptable for a draft; a long-term fix is to make the math module import-free of `_checkData` (move `checkVariables` out of `deviation.py`) — good follow-up, not a blocker.
+- **The self-skip round-trip fixture is the correct pattern for a known-broken dependency wheel.** It converts "tests silently fail on a corrupted read" into "tests skip with a precise message", and it would have caught exactly the L7 iteration-order swap (the synthetic rate-recovery test is also order-sensitive, since `growthRate` pairs adjacent entries). The trade-off — the suite goes quiet in precisely the environments where openpmd is broken — is documented in the docstring and the findings (L7). The one untestable link (literal `load_chunk()` on a healthy 3.11-3.13 wheel) is acknowledged; that is a property of the container, not of the branch.
+- **ESKHI-only modernisation scope is defensible.** The only consumer of the framework (`KHI_growthRate/bin/ci.sh` → `validate.sh`) runs ESKHI; MI is not wired into any flow. If the requester decides the flow is load-bearing, porting MI (its `argrelextrema` trim adds one step) is the natural next commit.
+- **CI: manual/weekly is the right default.** The arguments hold up: it would be the first simulation ever run in CI (CI is compile + `--help` smoke + quick/pytest today), it has unmet pre-conditions (L5/L6 + the fate decision), and 15-40 min of a CPU runner per MR is hard to justify before the flow's value is confirmed. The cheaper safety net that was *not* dismissed but only proposed is actually the one worth doing first: the synthetic `test_khi_growthrate.py` is < 2 s and would run in the existing `pypicongpu` job with a one-line change to `share/ci/install/pypicongpu.sh` (add an `end_to_end/test_khi_growthrate.py` invocation or un-mark just that file) — it guards the openPMD plumbing and the L7 class of regressions on every MR at zero extra runner cost. The per-MR *simulation* variant (e.g. a 300-step reduced run) is the reasonable middle ground to revisit once the fate decision lands; the doc's open question to the requester is the right framing.
+- **Alternative considered for the unit tests:** a `pyproject`/`sys.path` fixture would not have been enough — the framework's state lives in the *imported* `config` module (L3), so the snapshot/restore autouse fixture in `quick/testsuite/conftest.py` is the minimal correct workaround given "no deletions, no refactor" constraints.
+
+## 6. Prioritized next steps
+
+1. **m1:** fix `allParamsinFile` header splitting (`split()` instead of `split(" ")`) in `dataReader.py:102`, add the 2-column-header regression test, and record the pre-existing limitation (or the fix) in the findings doc.
+2. **m3:** add "fix `ci.sh`/`validate.sh` (dead `--fields_energy.period 10` at `ci.sh:120`; dead legacy validation)" to §6.2 pre-conditions (or show the corrected script) so the proposed job is honest as written.
+3. **m2:** add a `TestCMAKEFlagReader` regression test (or restate §3.4 accurately: which fixes have direct regression tests).
+4. **n6 + CI safety net:** add the negative verdict test; wire the synthetic `test_khi_growthrate.py` into the existing `pypicongpu` quick job (one-line `pypicongpu.sh` change) as the cheap per-MR guard.
+5. **nits:** fix the two line numbers (n1), the deviation sign (n2), the line count (n3), and the weekly-hours arithmetic (n4); consider `timeUnitSI` in `times_omega_pe` (n5).
+6. Then the documented follow-ups: requester decision on the KHI flow's fate, `picongpu.cfg` openPMD field dump for the KHI input set, upstream report of the openpmd-api 3.14 read-path bug (L7, reproduced here), and the L1-L4 latent-defect fixes.
+
+## FYI (inherited from base, not scored here)
+
+- **`test_validate_rocrate` xpass quirk:** under the default gate invocation (warnings plugin on, `filterwarnings = ["error"]`) the rocrate-validator's SHACL checks crash ("error during check ... SHACLCheck" in the log), the validator swallows the error and reports no issues, so the xfail-marked test **xpasses**; with `-p no:warnings` the checks run and find issues, and it xfails. Identical on dev — pre-existing, unrelated to this task; worth flagging to the picmi/rocrate owners (it also means the "1 xpassed" in the gate numbers is environment- and filter-dependent).
+- **Trimmed checkout:** this repository copy contains no C++ sources under `src/` (only `src/tools`). The audit's L5 claim is correctly scoped to "this checkout"; against full upstream the `fields_energy` plugin question would need re-checking before declaring the KHI flow dead upstream.
+- **Latent defects L1-L7** (openpmd branch of `searchParameter`, dead `-o` option, `eval`/`exec` + global config, `plot_2D` stub / `sys.exit(42)` swallowing, dead `--fields_energy` flag, no openPMD diagnostics in the KHI input set, broken openpmd-api 3.14 wheel) are all documented in the findings with evidence; fixing them is explicitly deferred, which matches the task's "do not delete / de-risk, don't re-architect" mandate.
+- **`growthRate`'s interval branch** (`math.py:60-65`) has the same "2-step difference" shape as the non-interval branch and is covered by `test_interval_returns_bounds`; no issue.
+- **`bx_amplitude_per_iteration`** loads the full mesh chunk per iteration (fine at 192·512·12); for much larger 3D fields a binned/reduced read would be the optimization to keep in mind.

--- a/docs/source/testing/structure.rst
+++ b/docs/source/testing/structure.rst
@@ -20,19 +20,28 @@ In order to then clearly present the result obtained to the user, an output is a
 | | ├── math.py
 | | └── _searchData.py
 | ├── Output
-| | ├── Log.py 
+| | ├── Log.py
 | | └── Viewer.py
 | ├── Reader
-| | ├── dataReader.py   
+| | ├── cmakeFlagReader.py
+| | ├── dataReader.py
 | | ├── jsonReader.py
-| | └── paramReader.py
+| | ├── paramReader.py
+| | └── readFiles.py
 | ├── Template
-| | ├── Data.py 
-| | └── main.py
+| | └── config.py
 | └── _checkData.py
 |
+| ./lib/python/test/setups
+| ├── MI
+| | ├── config.py
+| | └── main.py
+| └── ESKHI
+|   ├── config.py
+|   └── main.py
 
 In the above overview, all ``__init__.py`` and ``_manager.py`` files have been left out for the sake of clarity.
+Each case under ``lib/python/test/setups`` is a concrete test case built on the framework: ``config.py`` defines the case (paths, parameters, acceptance, theory/simulation evaluation), while ``main.py`` is the command-line entry point wrapping ``testsuite._manager.run_testsuite``.
 
 The subpackage reader reads out the data.
 It does not matter whether this data is used for the theory part or data from the simulation.

--- a/docs/source/testing/testbuilding.rst
+++ b/docs/source/testing/testbuilding.rst
@@ -8,23 +8,25 @@ General
 
 .. note::
 
-   Of course, all functionalities can be used to design your own test without resorting to the structure with Data.py.
+   Of course, all functionalities can be used to design your own test without resorting to the structure with config.py.
    This is assumed to be known and is therefore not discussed further here.
    Please refer to the documentation for the individual functionalities.
-    
-A template for developing a new test is available under ``.lib/python/test/testsuite/Template``.
-The files it contains can now be adapted to the new test in an extra folder. 
-The main.py file is only used to run the test and does not need to be changed any further.
-Much more important is the adaptation of Data.py. This is explained in more detail in the next section.
-If the test case is to be checked automatically by the ci afterwards, ci.sh and, if possible, a validate.sh must also be written after adapting Data.py.
+
+A template for developing a new test is available under ``lib/python/test/testsuite/Template``.
+The file it contains (``config.py``) can now be adapted to the new test in an extra folder,
+e.g. under ``lib/python/test/setups``.
+The ``main.py`` files of the existing setups (``lib/python/test/setups/MI``, ``lib/python/test/setups/ESKHI``)
+only start the test and do not need to be changed any further.
+Much more important is the adaptation of config.py. This is explained in more detail in the next section.
+If the test case is to be checked automatically by the ci afterwards, ci.sh and, if possible, a validate.sh must also be written after adapting config.py.
 To do this, adapt the existing ci.sh or validate.sh files for the sake of simplicity.
 
-Using Data.py
--------------
+Using config.py
+---------------
 
-The data.py file provides the test suite with all the essential data for running the test.
+The config.py file provides the test suite with all the essential data for running the test.
 The most important are the functions for calculating the data from theory and from the simulation.
-To better illustrate Data.py, the usage will be explained in more detail here using the MI example.
+To better illustrate config.py, the usage will be explained in more detail here using the MI example.
 
 1. Data not relevant to the test
 """"""""""""""""""""""""""""""""
@@ -69,7 +71,7 @@ In the MI example, no ``json_parameter`` is required:
 
     # parameter information found in .param files
     param_Parameter = ["gamma", "BASE_DENSITY_SI", "DELTA_T_SI"]
-    data_Parameter = ["Bz", "step"]
+    data_Parameter = ["Bx", "step"]
     
 3. test condition
 """""""""""""""""
@@ -117,7 +119,7 @@ Since both functions have a similar structure, we only consider the theoretical 
 
 .. code-block:: python
 
-    def theory(gamma, *args):
+    def theory(gamma, **kwargs):
         """
         this function indicates how the theoretical values
         can be calculated from the data. It must be filled out
@@ -131,7 +133,7 @@ Since both functions have a similar structure, we only consider the theoretical 
         out : theoretical values!
         """
         # gamma is calculated automatically, does not have to be passed
-        v = ts.Math.physics.calculateV_O()
+        v = ts.Math.physics.calculateV_O(gamma)
 
         return (v / (c * np.sqrt(gamma)))
         

--- a/docs/source/testing/usage.rst
+++ b/docs/source/testing/usage.rst
@@ -10,10 +10,11 @@ If a test is simulated manually, only the associated bashscript has to be execut
 
 .. note::
 
-    When running the bashscript, a temporary folder is created, labeled with the current date. 
+    When running the bashscript, an output folder is created, labeled with the current date.
     This folder contains all essential data of the test including the test result.
-    By default, this folder is automatically deleted after the test has been run and only the result is reported to the system as 0 or 1.
-    If you are interested in the data, the corresponding line in the bashscript must be commented out.
+    By default, this folder is kept and only the result is reported to the system as an exit code
+    (0 = passed, 1 = failed, 42 = error).
+    Pass ``--delete`` to remove the folder after the test has been run.
 
 On the other hand, the test suite should also be able to be used to evaluate existing simulations.
 No ci.bash needs to be executed for this.
@@ -22,4 +23,4 @@ Instead, it is advisable to run the main.py of the respective test directly.
 .. code-block:: bash
    :emphasize-lines: 1
 
-   .lib/python/test/testsuite/Template/main.py --help
+   python lib/python/test/setups/ESKHI/main.py --help

--- a/lib/python/test/picongpu/end_to_end/khi_growthrate.py
+++ b/lib/python/test/picongpu/end_to_end/khi_growthrate.py
@@ -49,11 +49,19 @@ def bx_amplitude_per_iteration(series):
 
 def times_omega_pe(series, density_si, gamma):
     """
-    The iteration times in units of 1/omega_pe: the openPMD time (SI)
-    scaled with the relativistic plasma frequency of the flow.
+    The iteration times in units of 1/omega_pe: the openPMD time
+    (time * timeUnitSI, SI) scaled with the relativistic plasma frequency
+    of the flow. PIConGPU writes timeUnitSI = 1.0; the factor is applied
+    anyway so the check stays correct for other unit conventions
+    (openpmd-api reports the standard default 1.0 when the attribute is
+    absent).
     """
     keys = sorted(series.iterations, key=int)
-    time_si = np.asarray([float(series.iterations[key].time) for key in keys])
+    time_si = []
+    for key in keys:
+        iteration = series.iterations[key]
+        time_si.append(float(iteration.time) * float(iteration.time_unit_SI))
+    time_si = np.asarray(time_si)
     omega_pe = physics.plasmafrequence(density=density_si, gamma=gamma, relativistic=True)
     return time_si * omega_pe
 

--- a/lib/python/test/picongpu/end_to_end/khi_growthrate.py
+++ b/lib/python/test/picongpu/end_to_end/khi_growthrate.py
@@ -1,0 +1,96 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: opencode
+License: GPLv3+
+
+KHI growth-rate validation consuming openPMD output (openpmd-api).
+
+This is the modernised re-expression of the validation in
+lib/python/test/setups/ESKHI: instead of re-parsing the legacy
+fields_energy.dat column and .param files, the simulation data (the
+amplitude of the dominant magnetic field Bx over time) are read directly
+from the openPMD series. The (corrected) growth-rate estimator and the
+deviation checks of testsuite.Math are kept as the reference.
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import openpmd_api as opmd
+
+# testsuite is a standalone package next to the picongpu test tree
+_TESTSUITE_ROOT = str(Path(__file__).resolve().parents[2])
+if _TESTSUITE_ROOT not in sys.path:
+    sys.path.insert(0, _TESTSUITE_ROOT)
+
+with warnings.catch_warnings():
+    # importing testsuite falls back to the template config and warns
+    warnings.simplefilter("ignore")
+    from testsuite.Math import deviation
+    from testsuite.Math import math
+    from testsuite.Math import physics
+
+
+def bx_amplitude_per_iteration(series):
+    """
+    The dominant magnetic field amplitude per iteration: the maximum of
+    |Bx| over the grid at each iteration. This is the f(t) series of the
+    legacy fields_energy.dat "Bx" column.
+    """
+    amplitudes = []
+    for key in sorted(series.iterations, key=int):
+        chunk = series.iterations[key].meshes["B"]["x"].load_chunk()
+        amplitudes.append(float(np.max(np.abs(chunk))))
+    return np.asarray(amplitudes)
+
+
+def times_omega_pe(series, density_si, gamma):
+    """
+    The iteration times in units of 1/omega_pe: the openPMD time (SI)
+    scaled with the relativistic plasma frequency of the flow.
+    """
+    keys = sorted(series.iterations, key=int)
+    time_si = np.asarray([float(series.iterations[key].time) for key in keys])
+    omega_pe = physics.plasmafrequence(density=density_si, gamma=gamma, relativistic=True)
+    return time_si * omega_pe
+
+
+def eskhi_growthrate_theory(gamma):
+    """
+    The analytic esKHI growth rate in units of omega_pe
+    (setups/ESKHI/config.py::theory).
+    """
+    return 1.0 / ((8.0**0.5) * gamma)
+
+
+def validate_eskhi_growthrate(openpmd_path, gamma, density_si, acceptance=0.2):
+    """
+    Compares the growth rate of the Bx amplitude in the openPMD series
+    against the analytic esKHI value, with the same acceptance as
+    setups/ESKHI/config.py (20%).
+
+    Return:
+    -------
+    dict with theory, simulation growth rate, deviation, and the
+    pass/fail verdict
+    """
+    series = opmd.Series(str(openpmd_path), opmd.Access.read_only)
+    try:
+        amplitude = bx_amplitude_per_iteration(series)
+        time = times_omega_pe(series, density_si, gamma)
+    finally:
+        series.close()
+
+    gamma_sim = math.growthRate(amplitude, time)
+    theory = eskhi_growthrate_theory(gamma)
+
+    return {
+        "theory": theory,
+        "simulation": gamma_sim,
+        "max_diff": float(deviation.getMinDifference(theory, gamma_sim)),
+        "difference_in_percentage": float(deviation.getDifferenceInPercentage(theory, gamma_sim)),
+        "result": bool(deviation.getTestResult(theory, gamma_sim, acceptance)),
+    }

--- a/lib/python/test/picongpu/end_to_end/test_khi_growthrate.py
+++ b/lib/python/test/picongpu/end_to_end/test_khi_growthrate.py
@@ -1,0 +1,138 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: opencode
+License: GPLv3+
+
+Checks the openPMD-based KHI growth-rate validation (khi_growthrate.py).
+
+The synthetic-series tests exercise the full pipeline (openPMD read ->
+growth rate -> analytic comparison) without a real KHI run. The last
+test validates the openPMD output of a real KHI run if it is provided
+via the PIC_KHI_OPENPMD environment variable.
+"""
+
+import os
+
+import numpy as np
+import openpmd_api as opmd
+import pytest
+
+from .khi_growthrate import (
+    bx_amplitude_per_iteration,
+    eskhi_growthrate_theory,
+    physics as ts_physics,
+    times_omega_pe,
+    validate_eskhi_growthrate,
+)
+
+
+@pytest.fixture(scope="module")
+def _openpmd_read_roundtrip(tmp_path_factory):
+    """
+    Self-check of the openpmd-api read path before running the checks on
+    it: write a two-iteration series and read it back.
+
+    In some environments (e.g. unofficial openpmd-api builds for Python
+    3.14) the read path returns corrupted data even though the files on
+    disk are correct (verifiable with h5py); the CI matrix uses Python
+    3.11-3.13, where this is expected to work.
+    """
+    path = tmp_path_factory.mktemp("openpmd_check") / "check.h5"
+    series = opmd.Series(str(path), opmd.Access.create)
+    for step in (0, 1):
+        iteration = series.iterations[step]
+        iteration.time = float(step)
+        iteration.dt = 1.0
+        component = iteration.meshes["E"]["x"]
+        component.reset_dataset(opmd.Dataset(np.dtype(np.float64), [4]))
+        component.store_chunk(np.full(4, float(step) + 1.0))
+    series.flush()
+    series.close()
+
+    series = opmd.Series(str(path), opmd.Access.read_only)
+    values = [float(series.iterations[k].meshes["E"]["x"].load_chunk()[0]) for k in (0, 1)]
+    series.close()
+
+    if values != [1.0, 2.0]:
+        pytest.skip(
+            "openpmd-api read path broken in this environment "
+            f"(round-trip returned {values!r}, expected [1.0, 2.0])"
+        )
+
+
+def _write_synthetic_series(path, gamma=1.6, density_si=1.0e25, n_cells=16, steps=(0, 5, 10, 15, 20, 25)):
+    """
+    Writes an openPMD series whose Bx field grows exponentially with the
+    analytic esKHI rate, so the validated growth rate must recover it.
+    """
+    omega_pe = ts_physics.plasmafrequence(density=density_si, gamma=gamma, relativistic=True)
+    dt = 0.1 / omega_pe
+
+    series = opmd.Series(str(path), opmd.Access.create)
+    for step in steps:
+        iteration = series.iterations[step]
+        iteration.time = step * dt
+        iteration.dt = dt
+        amplitude = np.exp(eskhi_growthrate_theory(gamma) * step * dt * omega_pe)
+        cells = (amplitude * (1.0 + 1e-3 * np.arange(n_cells))).astype(np.float64)
+        component = iteration.meshes["B"]["x"]
+        component.reset_dataset(opmd.Dataset(np.dtype(np.float64), [n_cells]))
+        component.store_chunk(cells)
+    series.flush()
+    series.close()
+
+
+class TestSyntheticSeries:
+    def test_growth_rate_recovers_analytic_rate(self, tmp_path, _openpmd_read_roundtrip):
+        gamma = 1.6
+        density_si = 1.0e25
+        path = tmp_path / "khi.h5"
+        _write_synthetic_series(path, gamma=gamma, density_si=density_si)
+
+        result = validate_eskhi_growthrate(path, gamma=gamma, density_si=density_si)
+
+        np.testing.assert_allclose(result["simulation"], eskhi_growthrate_theory(gamma), rtol=1e-6)
+
+    def test_validation_passes(self, tmp_path, _openpmd_read_roundtrip):
+        gamma = 1.6
+        density_si = 1.0e25
+        path = tmp_path / "khi.h5"
+        _write_synthetic_series(path, gamma=gamma, density_si=density_si)
+
+        result = validate_eskhi_growthrate(path, gamma=gamma, density_si=density_si)
+
+        assert result["result"] is True
+        assert abs(result["difference_in_percentage"]) < 1.0
+
+    def test_bx_amplitude_and_times(self, tmp_path, _openpmd_read_roundtrip):
+        gamma = 1.6
+        density_si = 1.0e25
+        path = tmp_path / "khi.h5"
+        _write_synthetic_series(path, gamma=gamma, density_si=density_si)
+
+        series = opmd.Series(str(path), opmd.Access.read_only)
+        try:
+            amplitude = bx_amplitude_per_iteration(series)
+            time = times_omega_pe(series, density_si, gamma)
+        finally:
+            series.close()
+
+        omega_pe = ts_physics.plasmafrequence(density=density_si, gamma=gamma, relativistic=True)
+        steps = np.array([0, 5, 10, 15, 20, 25])
+        expected = np.exp(eskhi_growthrate_theory(gamma) * steps * 0.1) * (1.0 + 1e-3 * 15)
+        np.testing.assert_allclose(amplitude, expected, rtol=1e-12)
+        np.testing.assert_allclose(time, steps * 0.1, rtol=1e-12)
+
+
+def test_real_khi_run_validation(_openpmd_read_roundtrip):
+    openpmd_path = os.environ.get("PIC_KHI_OPENPMD")
+    if not openpmd_path:
+        pytest.skip("set PIC_KHI_OPENPMD to the openPMD output of a KHI run")
+
+    # defaults from share/picongpu/tests/KHI_growthRate/include/picongpu/param
+    gamma = float(os.environ.get("PIC_KHI_GAMMA", "1.021"))
+    density_si = float(os.environ.get("PIC_KHI_DENSITY_SI", "1.0e25"))
+
+    result = validate_eskhi_growthrate(openpmd_path, gamma=gamma, density_si=density_si)
+    assert result["result"] is True

--- a/lib/python/test/picongpu/end_to_end/test_khi_growthrate.py
+++ b/lib/python/test/picongpu/end_to_end/test_khi_growthrate.py
@@ -60,10 +60,13 @@ def _openpmd_read_roundtrip(tmp_path_factory):
         )
 
 
-def _write_synthetic_series(path, gamma=1.6, density_si=1.0e25, n_cells=16, steps=(0, 5, 10, 15, 20, 25)):
+def _write_synthetic_series(
+    path, gamma=1.6, density_si=1.0e25, n_cells=16, steps=(0, 5, 10, 15, 20, 25), rate_factor=1.0
+):
     """
-    Writes an openPMD series whose Bx field grows exponentially with the
-    analytic esKHI rate, so the validated growth rate must recover it.
+    Writes an openPMD series whose Bx field grows exponentially with
+    rate_factor times the analytic esKHI rate, so the validated growth
+    rate must recover it.
     """
     omega_pe = ts_physics.plasmafrequence(density=density_si, gamma=gamma, relativistic=True)
     dt = 0.1 / omega_pe
@@ -73,7 +76,7 @@ def _write_synthetic_series(path, gamma=1.6, density_si=1.0e25, n_cells=16, step
         iteration = series.iterations[step]
         iteration.time = step * dt
         iteration.dt = dt
-        amplitude = np.exp(eskhi_growthrate_theory(gamma) * step * dt * omega_pe)
+        amplitude = np.exp(rate_factor * eskhi_growthrate_theory(gamma) * step * dt * omega_pe)
         cells = (amplitude * (1.0 + 1e-3 * np.arange(n_cells))).astype(np.float64)
         component = iteration.meshes["B"]["x"]
         component.reset_dataset(opmd.Dataset(np.dtype(np.float64), [n_cells]))
@@ -103,6 +106,20 @@ class TestSyntheticSeries:
 
         assert result["result"] is True
         assert abs(result["difference_in_percentage"]) < 1.0
+
+    def test_validation_fails_below_theory(self, tmp_path, _openpmd_read_roundtrip):
+        # negative case: a field growing at half the analytic rate is
+        # ~50 % off theory and must fail the 20 % acceptance, guarding the
+        # verdict/acceptance wiring (not just the rate recovery)
+        gamma = 1.6
+        density_si = 1.0e25
+        path = tmp_path / "khi.h5"
+        _write_synthetic_series(path, gamma=gamma, density_si=density_si, rate_factor=0.5)
+
+        result = validate_eskhi_growthrate(path, gamma=gamma, density_si=density_si)
+
+        assert result["result"] is False
+        assert result["difference_in_percentage"] == pytest.approx(50.0, abs=1.0)
 
     def test_bx_amplitude_and_times(self, tmp_path, _openpmd_read_roundtrip):
         gamma = 1.6

--- a/lib/python/test/picongpu/end_to_end/test_khi_growthrate.py
+++ b/lib/python/test/picongpu/end_to_end/test_khi_growthrate.py
@@ -56,8 +56,7 @@ def _openpmd_read_roundtrip(tmp_path_factory):
 
     if values != [1.0, 2.0]:
         pytest.skip(
-            "openpmd-api read path broken in this environment "
-            f"(round-trip returned {values!r}, expected [1.0, 2.0])"
+            f"openpmd-api read path broken in this environment (round-trip returned {values!r}, expected [1.0, 2.0])"
         )
 
 
@@ -118,7 +117,6 @@ class TestSyntheticSeries:
         finally:
             series.close()
 
-        omega_pe = ts_physics.plasmafrequence(density=density_si, gamma=gamma, relativistic=True)
         steps = np.array([0, 5, 10, 15, 20, 25])
         expected = np.exp(eskhi_growthrate_theory(gamma) * steps * 0.1) * (1.0 + 1e-3 * 15)
         np.testing.assert_allclose(amplitude, expected, rtol=1e-12)

--- a/lib/python/test/picongpu/quick/testsuite/conftest.py
+++ b/lib/python/test/picongpu/quick/testsuite/conftest.py
@@ -1,0 +1,36 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: opencode
+License: GPLv3+
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+# The standalone post-simulation validation framework (lib/python/test/testsuite)
+# is not part of the installed picongpu package, make it importable.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+
+@pytest.fixture(autouse=True)
+def _restore_template_config():
+    """
+    The framework's checkDirection() writes the resolved directory back into
+    the (global) template config module via exec(). Reset the module state
+    between tests so that no test observes another test's directories.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from testsuite.Template import config
+
+    snapshot = dict(vars(config))
+    yield
+    for key in list(vars(config)):
+        if key in snapshot:
+            setattr(config, key, snapshot[key])
+        else:
+            delattr(config, key)

--- a/lib/python/test/picongpu/quick/testsuite/test_math.py
+++ b/lib/python/test/picongpu/quick/testsuite/test_math.py
@@ -46,9 +46,7 @@ class TestGrowthRate:
 class TestDeviation:
     def test_get_difference(self):
         assert ts_deviation.getDifference(2.0, 5.0) == 3.0
-        np.testing.assert_allclose(
-            ts_deviation.getDifference(1.0, np.array([1.5, 2.0])), [0.5, 1.0]
-        )
+        np.testing.assert_allclose(ts_deviation.getDifference(1.0, np.array([1.5, 2.0])), [0.5, 1.0])
 
     def test_get_max_difference(self):
         assert ts_deviation.getMaxDifference(2.0, 5.0) == 3.0

--- a/lib/python/test/picongpu/quick/testsuite/test_math.py
+++ b/lib/python/test/picongpu/quick/testsuite/test_math.py
@@ -1,0 +1,95 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: opencode
+License: GPLv3+
+
+Unit tests for the math helpers of the standalone post-simulation
+validation framework (lib/python/test/testsuite/Math).
+"""
+
+import warnings
+
+import numpy as np
+from scipy.constants import c, e, epsilon_0, m_e
+
+with warnings.catch_warnings():
+    # importing testsuite falls back to the template config and warns
+    warnings.simplefilter("ignore")
+    from testsuite.Math import deviation as ts_deviation
+    from testsuite.Math import math as ts_math
+    from testsuite.Math import physics as ts_physics
+
+
+class TestGrowthRate:
+    def test_exponential_recovers_true_rate(self):
+        time = np.arange(50.0)
+        gamma_true = 0.7
+        f = np.exp(gamma_true * time)
+        np.testing.assert_allclose(ts_math.growthRate(f, time), gamma_true, rtol=1e-12)
+
+    def test_exponential_no_half_factor(self):
+        # regression test: growthRate used to return Gamma/2
+        time = np.arange(50.0)
+        f = 2.0**time
+        np.testing.assert_allclose(ts_math.growthRate(f, time), np.log(2.0), rtol=1e-12)
+
+    def test_interval_returns_bounds(self):
+        time = np.arange(50.0)
+        f = 2.0**time
+        gamma, start, stop = ts_math.growthRate(f, time, interval=(10.0, 30.0))
+        assert start == 10
+        assert stop == 30
+        np.testing.assert_allclose(gamma, np.log(2.0), rtol=1e-12)
+
+
+class TestDeviation:
+    def test_get_difference(self):
+        assert ts_deviation.getDifference(2.0, 5.0) == 3.0
+        np.testing.assert_allclose(
+            ts_deviation.getDifference(1.0, np.array([1.5, 2.0])), [0.5, 1.0]
+        )
+
+    def test_get_max_difference(self):
+        assert ts_deviation.getMaxDifference(2.0, 5.0) == 3.0
+        assert ts_deviation.getMaxDifference(np.array([1.0, 3.0]), np.array([1.5, 2.0])) == 1.0
+        assert ts_deviation.getMaxDifference(np.ones((2, 3)), np.ones((2, 3)) * 2.0) == 1.0
+
+    def test_get_min_difference(self):
+        # regression test: built-in min() raised TypeError on scalars
+        assert ts_deviation.getMinDifference(2.0, 2.5) == 0.5
+        assert ts_deviation.getMinDifference(np.array([1.0, 3.0]), np.array([1.5, 2.0])) == 0.5
+        assert ts_deviation.getMinDifference(np.ones((2, 3)), np.ones((2, 3)) + 2.0) == 2.0
+
+    def test_get_difference_in_percentage_relative_to_theory(self):
+        # (theory - max(simulation)) / theory * 100
+        assert ts_deviation.getDifferenceInPercentage(2.0, [1.0, 1.5]) == 25.0
+        # regression test: built-in max() raised TypeError on scalar simulation
+        np.testing.assert_allclose(ts_deviation.getDifferenceInPercentage(2.0, 1.9), 5.0)
+
+    def test_get_acceptance_range(self):
+        low, high = ts_deviation.getAcceptanceRange(1.0, 0.2)
+        assert low == 0.8
+        assert high == 1.2
+
+    def test_get_test_result(self):
+        assert ts_deviation.getTestResult(0.5, np.array([0.49, 0.5]), 0.2)
+        assert not ts_deviation.getTestResult(0.5, np.array([0.3]), 0.2)
+
+
+class TestPhysics:
+    def test_calculateV_O(self):
+        np.testing.assert_allclose(ts_physics.calculateV_O(10.0), c * np.sqrt(1 - 1 / 100))
+
+    def test_calculateBeta(self):
+        np.testing.assert_allclose(ts_physics.calculateBeta(gamma=10.0), np.sqrt(0.99))
+        np.testing.assert_allclose(ts_physics.calculateBeta(v_0=0.5 * c), 0.5)
+
+    def test_plasmafrequence(self):
+        density = 1.0e24
+        expected = np.sqrt(density * e**2 / (epsilon_0 * m_e))
+        np.testing.assert_allclose(ts_physics.plasmafrequence(density, relativistic=False), expected)
+        np.testing.assert_allclose(
+            ts_physics.plasmafrequence(density, gamma=2.0, relativistic=True),
+            expected / np.sqrt(2.0),
+        )

--- a/lib/python/test/picongpu/quick/testsuite/test_reader.py
+++ b/lib/python/test/picongpu/quick/testsuite/test_reader.py
@@ -9,6 +9,7 @@ validation framework (lib/python/test/testsuite/Reader) against small
 fixture files.
 """
 
+import gc
 import json
 import warnings
 
@@ -18,6 +19,7 @@ import pytest
 with warnings.catch_warnings():
     # importing testsuite falls back to the template config and warns
     warnings.simplefilter("ignore")
+    from testsuite.Reader import cmakeFlagReader
     from testsuite.Reader import dataReader
     from testsuite.Reader import jsonReader
     from testsuite.Reader import paramReader
@@ -72,6 +74,38 @@ class TestParamReader:
         reader = self._make_reader(tmp_path, "constexpr float_64 GAMMA = 2.0;\n")
         with pytest.raises(ValueError):
             reader.getValue("MISSING")
+
+
+class TestCMAKEFlagReader:
+    # regression test (task-10 review m2): getAllSetups opened the
+    # cmakeFlags file without closing it; under filterwarnings=error the
+    # resulting ResourceWarning fails any test exercising it
+
+    def _make_reader(self, tmp_path):
+        (tmp_path / "cmakeFlags").write_text(
+            'flags[0]="-DPIC_GAMMA=1.021;-DPIC_DENSITY=1.0e25"\n'
+            'flags[1]="-DPIC_GAMMA=1.0;-DPIC_DENSITY=2.0e25"\n'
+        )
+        (tmp_path / "cmakeFlagsSetup").write_text("selected setup:0\n")
+        return cmakeFlagReader.CMAKEFlagReader(direction=str(tmp_path))
+
+    def test_get_all_setups(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        assert reader.getAllSetups() == [
+            "-DPIC_GAMMA=1.021;-DPIC_DENSITY=1.0e25",
+            "-DPIC_GAMMA=1.0;-DPIC_DENSITY=2.0e25",
+        ]
+        # force collection of any file handle left open by getAllSetups; an
+        # unclosed handle would raise a ResourceWarning -> error here
+        gc.collect()
+
+    def test_used_setup(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        assert reader.usedSetup() == 0
+
+    def test_get_value(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        assert reader.getValue("PIC_GAMMA") == pytest.approx(1.021)
 
 
 class TestDataReader:

--- a/lib/python/test/picongpu/quick/testsuite/test_reader.py
+++ b/lib/python/test/picongpu/quick/testsuite/test_reader.py
@@ -36,9 +36,7 @@ class TestReadFiles:
 
     def test_set_direction(self, tmp_path):
         # regression test: setDirection used to raise AttributeError
-        rf = readFiles.ReadFiles(
-            fileExtension=".dat", direction="/tmp", directiontype="test_set_direction"
-        )
+        rf = readFiles.ReadFiles(fileExtension=".dat", direction="/tmp", directiontype="test_set_direction")
         # the constructor persists the directory into the (global) template
         # config; per the docstring, reset the directiontype before re-setting
         rf.setDirectiontype("test_set_direction_reset")
@@ -80,7 +78,7 @@ class TestDataReader:
     # "Bx" must not be the last header column: the parser keeps the trailing
     # newline of the header line on the last column name
     def _make_reader(self, tmp_path):
-        data = np.column_stack((np.arange(4.0), 2.0**np.arange(4.0), 3.0**np.arange(4.0)))
+        data = np.column_stack((np.arange(4.0), 2.0 ** np.arange(4.0), 3.0 ** np.arange(4.0)))
         with open(tmp_path / "fields_energy.dat", "w") as fh:
             fh.write("step Bx By\n")
             np.savetxt(fh, data)

--- a/lib/python/test/picongpu/quick/testsuite/test_reader.py
+++ b/lib/python/test/picongpu/quick/testsuite/test_reader.py
@@ -83,8 +83,7 @@ class TestCMAKEFlagReader:
 
     def _make_reader(self, tmp_path):
         (tmp_path / "cmakeFlags").write_text(
-            'flags[0]="-DPIC_GAMMA=1.021;-DPIC_DENSITY=1.0e25"\n'
-            'flags[1]="-DPIC_GAMMA=1.0;-DPIC_DENSITY=2.0e25"\n'
+            'flags[0]="-DPIC_GAMMA=1.021;-DPIC_DENSITY=1.0e25"\nflags[1]="-DPIC_GAMMA=1.0;-DPIC_DENSITY=2.0e25"\n'
         )
         (tmp_path / "cmakeFlagsSetup").write_text("selected setup:0\n")
         return cmakeFlagReader.CMAKEFlagReader(direction=str(tmp_path))

--- a/lib/python/test/picongpu/quick/testsuite/test_reader.py
+++ b/lib/python/test/picongpu/quick/testsuite/test_reader.py
@@ -75,8 +75,6 @@ class TestParamReader:
 
 
 class TestDataReader:
-    # "Bx" must not be the last header column: the parser keeps the trailing
-    # newline of the header line on the last column name
     def _make_reader(self, tmp_path):
         data = np.column_stack((np.arange(4.0), 2.0 ** np.arange(4.0), 3.0 ** np.arange(4.0)))
         with open(tmp_path / "fields_energy.dat", "w") as fh:
@@ -100,6 +98,32 @@ class TestDataReader:
         reader = self._make_reader(tmp_path)
         assert reader.getDatwithParam("Bx") == ["fields_energy.dat"]
         assert reader.getDatwithParam("Bz") == []
+
+
+class TestDataReaderTrailingColumn:
+    # regression test (task-10 review m1): allParamsinFile used to keep the
+    # trailing newline of the header line on the last column name
+    # ("Bx\n" != "Bx"), so a sought parameter that is the last header column
+    # was never found and getValue raised "could not be found"
+
+    def _make_reader(self, tmp_path):
+        data = np.column_stack((np.arange(4.0), 2.0 ** np.arange(4.0)))
+        with open(tmp_path / "fields_energy.dat", "w") as fh:
+            fh.write("step Bx\n")
+            np.savetxt(fh, data)
+        return dataReader.DataReader(direction=str(tmp_path))
+
+    def test_all_params_in_file(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        assert reader.allParamsinFile(str(tmp_path / "fields_energy.dat")) == ["step", "Bx"]
+
+    def test_get_datwith_param(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        assert reader.getDatwithParam("Bx") == ["fields_energy.dat"]
+
+    def test_get_value_trailing_column(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        np.testing.assert_allclose(reader.getValue("Bx"), [1.0, 2.0, 4.0, 8.0])
 
 
 class TestJSONReader:

--- a/lib/python/test/picongpu/quick/testsuite/test_reader.py
+++ b/lib/python/test/picongpu/quick/testsuite/test_reader.py
@@ -1,0 +1,122 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: opencode
+License: GPLv3+
+
+Unit tests for the Reader classes of the standalone post-simulation
+validation framework (lib/python/test/testsuite/Reader) against small
+fixture files.
+"""
+
+import json
+import warnings
+
+import numpy as np
+import pytest
+
+with warnings.catch_warnings():
+    # importing testsuite falls back to the template config and warns
+    warnings.simplefilter("ignore")
+    from testsuite.Reader import dataReader
+    from testsuite.Reader import jsonReader
+    from testsuite.Reader import paramReader
+    from testsuite.Reader import readFiles
+
+
+class TestReadFiles:
+    def test_requires_direction(self):
+        with pytest.raises(TypeError):
+            readFiles.ReadFiles(fileExtension=".dat")
+
+    def test_getters(self):
+        rf = readFiles.ReadFiles(fileExtension=".dat", direction="/tmp")
+        assert rf.getDirection() == "/tmp/"
+        assert rf.getFileExtension() == ".dat"
+
+    def test_set_direction(self, tmp_path):
+        # regression test: setDirection used to raise AttributeError
+        rf = readFiles.ReadFiles(
+            fileExtension=".dat", direction="/tmp", directiontype="test_set_direction"
+        )
+        # the constructor persists the directory into the (global) template
+        # config; per the docstring, reset the directiontype before re-setting
+        rf.setDirectiontype("test_set_direction_reset")
+        rf.setDirection(str(tmp_path))
+        assert rf.getDirection() == str(tmp_path) + "/"
+
+    def test_check_files_and_get_all(self, tmp_path):
+        (tmp_path / "a.dat").write_text("step Bx\n")
+        (tmp_path / "b.json").write_text("{}")
+        rf = readFiles.ReadFiles(fileExtension=".dat", direction=str(tmp_path))
+        assert rf.checkFilesInDir()
+        assert rf.getAllFiles() == ["a.dat"]
+
+
+class TestParamReader:
+    def _make_reader(self, tmp_path, content):
+        (tmp_path / "simulation.param").write_text(content)
+        return paramReader.ParamReader(direction=str(tmp_path))
+
+    def test_get_value(self, tmp_path):
+        reader = self._make_reader(tmp_path, "constexpr float_64 BASE_DENSITY_SI = 1.0e24;\n")
+        assert reader.getValue("BASE_DENSITY_SI") == pytest.approx(1.0e24)
+
+    def test_get_value_with_multiplication(self, tmp_path):
+        reader = self._make_reader(tmp_path, "constexpr float_64 DELTA_T_SI = 1.79e-16 * 0.86;\n")
+        assert reader.getValue("DELTA_T_SI") == pytest.approx(1.79e-16 * 0.86)
+
+    def test_get_param(self, tmp_path):
+        reader = self._make_reader(tmp_path, "constexpr float_64 GAMMA = 2.0;\n")
+        assert reader.getParam("GAMMA") == ["simulation.param"]
+
+    def test_get_value_missing(self, tmp_path):
+        reader = self._make_reader(tmp_path, "constexpr float_64 GAMMA = 2.0;\n")
+        with pytest.raises(ValueError):
+            reader.getValue("MISSING")
+
+
+class TestDataReader:
+    # "Bx" must not be the last header column: the parser keeps the trailing
+    # newline of the header line on the last column name
+    def _make_reader(self, tmp_path):
+        data = np.column_stack((np.arange(4.0), 2.0**np.arange(4.0), 3.0**np.arange(4.0)))
+        with open(tmp_path / "fields_energy.dat", "w") as fh:
+            fh.write("step Bx By\n")
+            np.savetxt(fh, data)
+        return dataReader.DataReader(direction=str(tmp_path))
+
+    def test_all_params_in_file(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        assert reader.allParamsinFile(str(tmp_path / "fields_energy.dat"))[:2] == ["step", "Bx"]
+
+    def test_get_value_step(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        np.testing.assert_allclose(reader.getValue("step"), [0.0, 1.0, 2.0, 3.0])
+
+    def test_get_value_column(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        np.testing.assert_allclose(reader.getValue("Bx"), [1.0, 2.0, 4.0, 8.0])
+
+    def test_get_datwith_param(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        assert reader.getDatwithParam("Bx") == ["fields_energy.dat"]
+        assert reader.getDatwithParam("Bz") == []
+
+
+class TestJSONReader:
+    def _make_reader(self, tmp_path):
+        (tmp_path / "meta.json").write_text(json.dumps({"gamma": {"values": 2.5}}))
+        return jsonReader.JSONReader(direction=str(tmp_path))
+
+    def test_get_value(self, tmp_path):
+        assert self._make_reader(tmp_path).getValue("gamma") == 2.5
+
+    def test_get_json_with_param(self, tmp_path):
+        reader = self._make_reader(tmp_path)
+        assert reader.getJSONwithParam("gamma") == ["meta.json"]
+        assert reader.getJSONwithParam("other") == []
+
+    def test_get_value_missing(self, tmp_path):
+        with pytest.raises(ValueError):
+            self._make_reader(tmp_path).getValue("other")

--- a/lib/python/test/testsuite/Math/deviation.py
+++ b/lib/python/test/testsuite/Math/deviation.py
@@ -70,9 +70,7 @@ def getMaxDifference(theory, simulation):
     out : The maximum in the deviation
     """
 
-    difference = np.abs(theory - simulation)
-
-    return max(difference)
+    return np.max(np.abs(theory - simulation))
 
 
 def getMinDifference(theory, simulation):
@@ -102,9 +100,7 @@ def getMinDifference(theory, simulation):
     out : The minimum in the deviation
     """
 
-    difference = np.abs(min(theory - simulation))
-
-    return difference
+    return float(np.min(np.abs(theory - simulation)))
 
 
 def getDifference(theory, simulation):
@@ -142,11 +138,12 @@ def getDifference(theory, simulation):
 def getDifferenceInPercentage(theory, simulation):
     """
     calculates the difference between the theory value and
-    the simulation's maximum value in percentage
+    the simulation's maximum value in percentage,
+    relative to the theory value
 
     Calculates:
     --------
-    (theory - max(simulation)) / simulation * 100
+    (theory - max(simulation)) / theory * 100
 
     Input:
     -------
@@ -169,7 +166,7 @@ def getDifferenceInPercentage(theory, simulation):
 
     """
 
-    simMax = max(simulation)
+    simMax = np.max(simulation)
     return (theory - simMax) / theory * 100
 
 

--- a/lib/python/test/testsuite/Math/math.py
+++ b/lib/python/test/testsuite/Math/math.py
@@ -50,7 +50,7 @@ def growthRate(f, time, interval=None):
 
     if interval is None:
         # The initial value is zero, to avoid noise it is removed
-        Gamma = 0.5 * np.log(f[3:] / f[1:-2]) / (time[3:] - time[1:-2])
+        Gamma = np.log(f[3:] / f[1:-2]) / (time[3:] - time[1:-2])
         return Gamma
 
     else:
@@ -60,10 +60,8 @@ def growthRate(f, time, interval=None):
         # calculate upper limit
         stop = np.where(time > interval[1])[0][0] - 1
 
-        Gamma = (
-            0.5
-            * np.log(f[start + 1 : stop + 1] / f[start - 1 : stop - 1])
-            / (time[start + 1 : stop + 1] - time[start - 1 : stop - 1])
+        Gamma = np.log(f[start + 1 : stop + 1] / f[start - 1 : stop - 1]) / (
+            time[start + 1 : stop + 1] - time[start - 1 : stop - 1]
         )
 
     return Gamma, start, stop

--- a/lib/python/test/testsuite/Reader/cmakeFlagReader.py
+++ b/lib/python/test/testsuite/Reader/cmakeFlagReader.py
@@ -95,8 +95,8 @@ class CMAKEFlagReader(rF.ReadFiles):
 
         flags = []
 
-        file = open(self._direction + "cmakeFlags", "r")
-        lines = file.readlines()
+        with open(self._direction + "cmakeFlags", "r") as file:
+            lines = file.readlines()
 
         i = 0
         for line in lines:

--- a/lib/python/test/testsuite/Reader/dataReader.py
+++ b/lib/python/test/testsuite/Reader/dataReader.py
@@ -209,13 +209,13 @@ class DataReader(rF.ReadFiles):
             raise ValueError("The parameter could be found more than once. Please use the parameter p_type for this")
 
         if "step" == parameter and step_direction is None:
-            result = np.loadtxt(self._direction + all_files[0])[:, 0]
+            result = np.loadtxt(self._direction + all_files[0], skiprows=1)[:, 0]
         elif "step" == parameter:
-            result = np.loadtxt(self._direction + step_direction)[:, 0]
+            result = np.loadtxt(self._direction + step_direction, skiprows=1)[:, 0]
         elif len(all_files) == 1:
             params = self.allParamsinFile(self._direction + all_files[0])
             index = params.index(parameter)
-            result = np.loadtxt(self._direction + all_files[0])[:, index]
+            result = np.loadtxt(self._direction + all_files[0], skiprows=1)[:, index]
         elif len(all_files) == 0:
             raise ValueError("The given Parameter could not be found")
         else:
@@ -225,7 +225,7 @@ class DataReader(rF.ReadFiles):
                 part_file = all_files[particles.index(p_type)]
                 params = self.allParamsinFile(self._direction + part_file)
                 index = params.index(parameter)
-                result = np.loadtxt(self._direction + part_file)[:, index]
+                result = np.loadtxt(self._direction + part_file, skiprows=1)[:, index]
             except Exception:
                 raise ValueError(
                     "More than one file containing the parameter"

--- a/lib/python/test/testsuite/Reader/dataReader.py
+++ b/lib/python/test/testsuite/Reader/dataReader.py
@@ -99,7 +99,7 @@ class DataReader(rF.ReadFiles):
             raise ValueError("The passed parameter file is not a .dat file.")
 
         with open(file) as fi:
-            line = fi.readlines()[0].split(" ")
+            line = fi.readlines()[0].split()
 
         result = [entry.split("[")[0] for entry in line]
         if "step" in result[0]:

--- a/lib/python/test/testsuite/Reader/paramReader.py
+++ b/lib/python/test/testsuite/Reader/paramReader.py
@@ -190,9 +190,8 @@ class ParamReader(rF.ReadFiles):
 
         result = {}
 
-        lines = open(self._direction + filename, "r")
-
-        allLines = lines.readlines()
+        with open(self._direction + filename, "r") as lines:
+            allLines = lines.readlines()
 
         number = 0
 

--- a/lib/python/test/testsuite/Reader/readFiles.py
+++ b/lib/python/test/testsuite/Reader/readFiles.py
@@ -91,7 +91,7 @@ class ReadFiles:
         ------
         If a directiontype was specified, it must first be reset
         """
-        direction = cD.checkDirection(variable=self.directiontype, direction=direction)
+        direction = cD.checkDirection(variable=self._directiontype, direction=direction)
 
         self._direction = direction + "/"
 


### PR DESCRIPTION
## What

Audit of `lib/python/test/{testsuite,setups}`: what are they testing, and
what is their quality? Delivered as verified defects (with reproducible
commands), a set of cleanup and modernisation commits on this branch
(openPMD modernisation among them), and a costed recommendation for CI
integration. Exploratory task — findings-first, not PR-perfect.

## Rework (2026-08-31)

APPROVE verdict; the minor/nit findings fixed (trailing-column fix + test,
B5 regression test, made the proposed CI job actually runnable, factual nits
in the findings doc, ruff format). See `TASK-10-RESPONSE.md`.

## Verification

`pytest quick/` green (201), `pre-commit run --all-files` green at the
branch tip.

---
**Internal review PR** (fork `chillenzer/picongpu`). QA cycle completed on-branch: implementation -> independent review (`TASK-10-REVIEW.md`) -> rework (`TASK-10-RESPONSE.md`), all committed at the branch root alongside `TASK-10-FINDINGS.md`.

Base will be re-pointed to the upstream development branch once approved.