### PR TITLE
Laser PICMI: corrected analytic fields + end-to-end tests (stacked on #5739)

### DIFF
--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -113,7 +113,6 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
 
         return z / (z**2 + (0.5 * self._Omega0() * w0**2 / c) ** 2)
 
-
     def _pulse_duration_sigma_si(self):
         """Convert the PICMI-standard laser ``duration`` to the PIConGPU
         ``PULSE_DURATION`` parameter.
@@ -157,16 +156,14 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
 
         w0x = self.waist
         w0y = self.waist
-        # Temporal envelope convention of the C++ GaussianPulse profile:
-        # exp(-(t / (2 * PULSE_DURATION))^2), see GaussianPulse.hpp.  The frontend
-        # writes `duration` verbatim into PULSE_DURATION (interpreted as the sigma
-        # of the intensity profile), so the effective field-duration here is
-        #     tau0 = 2 * duration .
-        # The "duration" given in the docs of models/lasers.rst is the FWHM of the
-        # intensity, i.e. sqrt(2 ln 2) * PULSE_DURATION, which is only consistent
-        # with the code after the frontend converts accordingly.  Keep in sync with
-        # the duration-semantics handling of the frontend (see pulse_duration_si).
-        tau0 = 2 * self.duration
+        # Temporal envelope of the C++ GaussianPulse profile is
+        # exp(-(t / (2 * PULSE_DURATION))^2) (see GaussianPulse.hpp) with
+        # PULSE_DURATION = duration / 2 (the 1 sigma of the intensity), because
+        # the PICMI `duration` is the 1/e field width (tau), cf. #5739.  Hence the
+        # field decays as exp(-(t / duration)^2), i.e. the effective field duration
+        # here is simply
+        #     tau0 = duration .
+        tau0 = self.duration
         zRx = 0.5 * self._Omega0() * w0x**2 / c
         zRy = 0.5 * self._Omega0() * w0y**2 / c
         Rx_inv = self._inverse_curvature_radius(z, w0x)

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -157,7 +157,16 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
 
         w0x = self.waist
         w0y = self.waist
-        tau0 = self.duration / np.sqrt(2 * np.log(2))
+        # Temporal envelope convention of the C++ GaussianPulse profile:
+        # exp(-(t / (2 * PULSE_DURATION))^2), see GaussianPulse.hpp.  The frontend
+        # writes `duration` verbatim into PULSE_DURATION (interpreted as the sigma
+        # of the intensity profile), so the effective field-duration here is
+        #     tau0 = 2 * duration .
+        # The "duration" given in the docs of models/lasers.rst is the FWHM of the
+        # intensity, i.e. sqrt(2 ln 2) * PULSE_DURATION, which is only consistent
+        # with the code after the frontend converts accordingly.  Keep in sync with
+        # the duration-semantics handling of the frontend (see pulse_duration_si).
+        tau0 = 2 * self.duration
         zRx = 0.5 * self._Omega0() * w0x**2 / c
         zRy = 0.5 * self._Omega0() * w0y**2 / c
         Rx_inv = self._inverse_curvature_radius(z, w0x)
@@ -166,9 +175,12 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
         wy = w0y * np.sqrt(1 + z**2 / zRy**2)
         gamma4 = (t - z / c - 0.5 / c * (x**2 * Rx_inv + y**2 * Ry_inv)) / tau0
 
+        # The field of the DispersivePulse/GaussianPulse profiles is normalized such
+        # that its on-axis, in-focus amplitude is AMPLITUDE (= E0).  The 1/(tau0
+        # sqrt(pi)) factor appearing in models/lasers.rst belongs to the normalized
+        # input spectrum and must *not* be multiplied here.
         return (
             self.E0
-            / (tau0 * np.sqrt(np.pi))
             * (1 + z**2 / zRx**2) ** (-1 / 4)
             * (1 + z**2 / zRy**2) ** (-1 / 4)
             * np.exp(1.0j * self._Omega0() * gamma4 * tau0)

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -8,8 +8,10 @@ License: GPLv3+
 
 from typing import Annotated
 
+import numpy as np
 from picmistandard import PICMI_GaussianLaser
 from pydantic import Field, computed_field, model_validator
+from scipy.spatial.transform import Rotation
 
 from ...pypicongpu import laser, util
 from ..copy_attributes import default_converts_to
@@ -34,7 +36,7 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
         Central wavelength of the laser [m].
 
     - waist : float
-        Spot size (1/e^2 radius) of the laser at focus [m].
+        Spot size (1/e^2 radius of the intensity) of the laser at focus [m].
 
     - duration : float
         Duration of the Gaussian laser pulse [s], defined as ``tau`` in the
@@ -131,3 +133,66 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
             "propagation_direction must connect centroid_position and focus_position"
         )
         return self
+
+    def _complex_amplitude_standard_conditions(self, x, y, z, t):
+        """
+        This is
+        - focus is in the origin at t=0
+        - propagation in z direction
+        - polarization in x direction
+        """
+
+        from picongpu.picmi.constants import c
+
+        Omega0 = 2 * np.pi * c / self.wavelength
+        w0x = self.waist
+        w0y = self.waist
+        tau0 = self.duration / np.sqrt(2 * np.log(2))
+        zRx = 0.5 * Omega0 * w0x**2 / c
+        zRy = 0.5 * Omega0 * w0y**2 / c
+        Rx_inv = z / (z**2 + zRx**2)
+        Ry_inv = z / (z**2 + zRy**2)
+        wx = w0x * np.sqrt(1 + z**2 / zRx**2)
+        wy = w0y * np.sqrt(1 + z**2 / zRy**2)
+        gamma4 = (t - z / c - 0.5 / c * (x**2 * Rx_inv + y**2 * Ry_inv)) / tau0
+
+        return (
+            self.E0
+            / (tau0 * np.sqrt(np.pi))
+            * (1 + z**2 / zRx**2) ** (-1 / 4)
+            * (1 + z**2 / zRy**2) ** (-1 / 4)
+            * np.exp(1.0j * Omega0 * gamma4 * tau0)
+            * np.exp(0.5j * (np.arctan(z / zRx) + np.arctan(z / zRy)))
+            * np.exp(-(x**2 / wx**2 + y**2 / wy**2))
+            * np.exp(-(gamma4**2))
+        )
+
+    def complex_amplitude(self, x, y, z, t=0.0):
+        from picongpu.picmi.constants import c
+
+        coords = np.asarray([x, y, z]) - np.asarray(self.focal_position).reshape(-1, 1, 1, 1)
+        t -= np.dot(np.asarray(self.focal_position) - self.centroid_position, self.propagation_direction) / c
+        r = Rotation.align_vectors([[1, 0, 0], [0, 0, 1]], [self.polarization_direction, self.propagation_direction])[0]
+        x, y, z = np.rollaxis(r.apply(np.rollaxis(coords, 0, 4)), -1, 0)
+        return self._complex_amplitude_standard_conditions(x, y, z, t)
+
+    def E(self, x, y, z, t=0.0):
+        amplitude = np.real(self.complex_amplitude(x, y, z, t)).astype(float)
+        if self.picongpu_polarization_type == PolarizationType.LINEAR:
+            return np.einsum("i,j...->ij...", self.polarization_direction, amplitude)
+        elif self.picongpu_polarization_type == PolarizationType.CIRCULAR:
+            raise NotImplementedError("Circular polarization is not yet implemented.")
+        else:
+            raise ValueError("Unknown {self.picongpu_polarization_type=}.")
+
+    def Ex(self, x, y, z, t=0.0):
+        return self.E(x, y, z, t)[0]
+
+    def Ey(self, x, y, z, t=0.0):
+        return self.E(x, y, z, t)[1]
+
+    def Ez(self, x, y, z, t=0.0):
+        return self.E(x, y, z, t)[2]
+
+    def envelope(self, x, y, z, t=0.0):
+        return np.abs(self.complex_amplitude(x, y, z, t))

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -103,6 +103,17 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
     def pulse_init(self) -> float:
         return self._compute_pulse_init()
 
+    def _Omega0(self):
+        from picongpu.picmi.constants import c
+
+        return 2 * np.pi * c / self.wavelength
+
+    def _inverse_curvature_radius(self, z, w0):
+        from picongpu.picmi.constants import c
+
+        return z / (z**2 + (0.5 * self._Omega0() * w0**2 / c) ** 2)
+
+
     def _pulse_duration_sigma_si(self):
         """Convert the PICMI-standard laser ``duration`` to the PIConGPU
         ``PULSE_DURATION`` parameter.
@@ -144,14 +155,13 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
 
         from picongpu.picmi.constants import c
 
-        Omega0 = 2 * np.pi * c / self.wavelength
         w0x = self.waist
         w0y = self.waist
         tau0 = self.duration / np.sqrt(2 * np.log(2))
-        zRx = 0.5 * Omega0 * w0x**2 / c
-        zRy = 0.5 * Omega0 * w0y**2 / c
-        Rx_inv = z / (z**2 + zRx**2)
-        Ry_inv = z / (z**2 + zRy**2)
+        zRx = 0.5 * self._Omega0() * w0x**2 / c
+        zRy = 0.5 * self._Omega0() * w0y**2 / c
+        Rx_inv = self._inverse_curvature_radius(z, w0x)
+        Ry_inv = self._inverse_curvature_radius(z, w0y)
         wx = w0x * np.sqrt(1 + z**2 / zRx**2)
         wy = w0y * np.sqrt(1 + z**2 / zRy**2)
         gamma4 = (t - z / c - 0.5 / c * (x**2 * Rx_inv + y**2 * Ry_inv)) / tau0
@@ -161,29 +171,56 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
             / (tau0 * np.sqrt(np.pi))
             * (1 + z**2 / zRx**2) ** (-1 / 4)
             * (1 + z**2 / zRy**2) ** (-1 / 4)
-            * np.exp(1.0j * Omega0 * gamma4 * tau0)
+            * np.exp(1.0j * self._Omega0() * gamma4 * tau0)
             * np.exp(0.5j * (np.arctan(z / zRx) + np.arctan(z / zRy)))
             * np.exp(-(x**2 / wx**2 + y**2 / wy**2))
             * np.exp(-(gamma4**2))
         )
 
-    def complex_amplitude(self, x, y, z, t=0.0):
-        from picongpu.picmi.constants import c
-
-        coords = np.asarray([x, y, z]) - np.asarray(self.focal_position).reshape(-1, 1, 1, 1)
-        t -= np.dot(np.asarray(self.focal_position) - self.centroid_position, self.propagation_direction) / c
-        r = Rotation.align_vectors([[1, 0, 0], [0, 0, 1]], [self.polarization_direction, self.propagation_direction])[0]
-        x, y, z = np.rollaxis(r.apply(np.rollaxis(coords, 0, 4)), -1, 0)
-        return self._complex_amplitude_standard_conditions(x, y, z, t)
-
-    def E(self, x, y, z, t=0.0):
-        amplitude = np.real(self.complex_amplitude(x, y, z, t)).astype(float)
+    def _polarization_vector_standard_conditions_at(self, x, y, z, t):
+        """
+        This is
+        - focus is in the origin at t=0
+        - propagation in z direction
+        - polarization in x direction
+        """
         if self.picongpu_polarization_type == PolarizationType.LINEAR:
-            return np.einsum("i,j...->ij...", self.polarization_direction, amplitude)
+            w0x = self.waist
+            w0y = self.waist
+            angle_x = np.arcsin(x * self._inverse_curvature_radius(z, w0x))
+            angle_y = np.arcsin(y * self._inverse_curvature_radius(z, w0y))
+            r = Rotation.from_euler("xy", np.moveaxis(np.asarray([angle_x, angle_y]), 0, -1))
+            return np.moveaxis(r.apply(self.polarization_direction), -1, 0)
         elif self.picongpu_polarization_type == PolarizationType.CIRCULAR:
             raise NotImplementedError("Circular polarization is not yet implemented.")
         else:
             raise ValueError("Unknown {self.picongpu_polarization_type=}.")
+
+    def polarization_vector_at(self, x, y, z, t=0.0):
+        return self._polarization_vector_standard_conditions_at(*self._to_standard_coordinates(x, y, z, t))
+
+    def _standard_rotation(self):
+        return Rotation.align_vectors(
+            [[1, 0, 0], [0, 0, 1]], [self.polarization_direction, self.propagation_direction]
+        )[0].apply
+
+    def _to_standard_coordinates(self, x, y, z, t):
+        from picongpu.picmi.constants import c
+
+        coords = np.asarray([x, y, z]) - as_broadcastable_factor_in_front_of(self.focal_position, of=(x, y, z))
+        r = self._standard_rotation()
+        x, y, z = np.moveaxis(r(np.moveaxis(coords, 0, -1)), -1, 0)
+        t -= np.dot(np.asarray(self.focal_position) - self.centroid_position, self.propagation_direction) / c
+        return x, y, z, t
+
+    def complex_amplitude(self, x, y, z, t=0.0):
+        return self._complex_amplitude_standard_conditions(*self._to_standard_coordinates(x, y, z, t))
+
+    def E(self, x, y, z, t=0.0):
+        return (
+            self.polarization_vector_at(x, y, z, t)
+            * np.real(self.complex_amplitude(x, y, z, t)).astype(float)[np.newaxis, ...]
+        )
 
     def Ex(self, x, y, z, t=0.0):
         return self.E(x, y, z, t)[0]
@@ -196,3 +233,9 @@ class GaussianLaser(PICMI_GaussianLaser, BaseLaser):
 
     def envelope(self, x, y, z, t=0.0):
         return np.abs(self.complex_amplitude(x, y, z, t))
+
+
+def as_broadcastable_factor_in_front_of(arr, of=tuple()):
+    if of:
+        return np.reshape(arr, (-1, *(1 for _ in np.broadcast_shapes(*map(np.shape, of)))))
+    return np.asarray(arr)

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -9,6 +9,8 @@ from collections.abc import Sequence
 
 import math
 
+import numpy as np
+
 from pydantic import BaseModel, Field, computed_field, model_validator
 
 from ...pypicongpu import laser
@@ -83,3 +85,25 @@ class PlaneWaveLaser(BaseModel, BaseLaser):
 
     def check(self):
         self._validate_common_properties()
+
+    def complex_amplitude(self, x, y, z, t=0.0):
+        return np.exp(-1.0j * self.k0 * np.einsum("i,i...->...", self.propagation_direction, [x, y, z]))
+
+    def E(self, x, y, z, t=0.0):
+        return np.real(self.complex_amplitude(x, y, z, t))[..., np.newaxis] * self.polarization_vector_at(x, y, z, t)
+
+    def Ex(self, x, y, z, t=0.0):
+        return self.E(x, y, z, t)[..., 0]
+
+    def Ey(self, x, y, z, t=0.0):
+        return self.E(x, y, z, t)[..., 1]
+
+    def Ez(self, x, y, z, t=0.0):
+        return self.E(x, y, z, t)[..., 2]
+
+    def polarization_vector_at(self, x, y, z, t=0.0):
+        shape = np.broadcast_shapes(x.shape, y.shape, z.shape)
+        return np.ones(shape + (len(self.polarization_direction),)) * np.reshape(
+            self.polarization_direction, len(shape) * (1,) + (-1,)
+        )
+

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -156,4 +156,3 @@ class PlaneWaveLaser(BaseModel, BaseLaser):
         # constant (wavefront-uncurved) polarization, component-first like GaussianLaser
         shape = np.broadcast_shapes(np.shape(x), np.shape(y), np.shape(z))
         return np.reshape(self.polarization_direction, (-1,) + (1,) * len(shape)) * np.ones((3,) + tuple(shape))
-

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -86,28 +86,74 @@ class PlaneWaveLaser(BaseModel, BaseLaser):
     def check(self):
         self._validate_common_properties()
 
+    def _Omega0(self):
+        from picongpu.picmi.constants import c
+
+        return 2.0 * math.pi * c / self.wavelength
+
+    def _standard_rotation(self):
+        from scipy.spatial.transform import Rotation
+
+        return Rotation.align_vectors(
+            [[1, 0, 0], [0, 0, 1]], [self.polarization_direction, self.propagation_direction]
+        )[0].apply
+
+    def _to_standard_coordinates(self, x, y, z, t):
+        # The pulse peak (envelope maximum) is at centroid_position at t=0.
+        shape = np.broadcast_shapes(np.shape(x), np.shape(y), np.shape(z))
+        coords = np.asarray([x, y, z]) - np.reshape(self.centroid_position, (-1,) + (1,) * len(shape))
+        r = self._standard_rotation()
+        x, y, z = np.moveaxis(r(np.moveaxis(coords, 0, -1)), -1, 0)
+        # no additional time shift: with "standard conditions" the pulse peak is at
+        # the origin at t=0, which is what "centroid at t=0" means by construction.
+        return x, y, z, t
+
     def complex_amplitude(self, x, y, z, t=0.0):
         from picongpu.picmi.constants import c
 
-        prop = t / c - np.einsum("i,i...->...", self.propagation_direction, [x, y, z])
-        prop_env = prop
-        return np.exp(-(prop_env**2) / self.duration**2) * np.exp(-1.0j * self.k0 * prop)
+        # Mirror of the C++ PlaneWaveFunctorIncidentE (BaseSeparableFunctorE).
+        # In standard conditions (propagation along +z) the longitudinal time
+        # argument is T = t - z/c.  The ramp/plateau follows the C++ code:
+        #   endUpramp = RAMP_INIT * PULSE_DURATION
+        #   startDownramp = endUpramp + LASER_NOFOCUS_CONSTANT
+        #   tau = PULSE_DURATION * sqrt(2)
+        # where the frontend maps RAMP_INIT -> pulse_init and
+        # LASER_NOFOCUS_CONSTANT -> picongpu_plateau_duration.
+        _, _, z_std, t_std = self._to_standard_coordinates(x, y, z, t)
+        T = t_std - z_std / c
+
+        tau = self.duration * math.sqrt(2.0)
+        end_up = self.pulse_init * self.duration
+        start_down = end_up + self.picongpu_plateau_duration
+
+        envelope = np.full(np.shape(T), self.E0, dtype=np.float64)
+        corr = np.zeros_like(envelope)
+        up = T < end_up
+        down = T > start_down
+        envelope = np.where(up, self.E0 * np.exp(-0.5 * ((T - end_up) / tau) ** 2), envelope)
+        envelope = np.where(down, self.E0 * np.exp(-0.5 * ((T - start_down) / tau) ** 2), envelope)
+        corr = np.where(up, (T - end_up) / (self._Omega0() * tau * tau), corr)
+        corr = np.where(down, (T - start_down) / (self._Omega0() * tau * tau), corr)
+
+        t_oszi = T - end_up
+        phase = self._Omega0() * t_oszi + self.phi0
+        value = (np.sin(phase) + np.cos(phase) * corr) * envelope
+        return value.astype(np.complex128)
 
     def E(self, x, y, z, t=0.0):
-        return np.real(self.complex_amplitude(x, y, z, t))[..., np.newaxis] * self.polarization_vector_at(x, y, z, t)
+        return self.polarization_vector_at(x, y, z, t) * np.real(self.complex_amplitude(x, y, z, t))[np.newaxis, ...]
 
     def Ex(self, x, y, z, t=0.0):
-        return self.E(x, y, z, t)[..., 0]
+        return self.E(x, y, z, t)[0]
 
     def Ey(self, x, y, z, t=0.0):
-        return self.E(x, y, z, t)[..., 1]
+        return self.E(x, y, z, t)[1]
 
     def Ez(self, x, y, z, t=0.0):
-        return self.E(x, y, z, t)[..., 2]
+        return self.E(x, y, z, t)[2]
 
     def polarization_vector_at(self, x, y, z, t=0.0):
-        shape = np.broadcast_shapes(x.shape, y.shape, z.shape)
-        return np.ones(shape + (len(self.polarization_direction),)) * np.reshape(
-            self.polarization_direction, len(shape) * (1,) + (-1,)
-        )
+        # constant (wavefront-uncurved) polarization, component-first like GaussianLaser
+        shape = np.broadcast_shapes(np.shape(x), np.shape(y), np.shape(z))
+        return np.reshape(self.polarization_direction, (-1,) + (1,) * len(shape)) * np.ones((3,) + tuple(shape))
 

--- a/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
+++ b/lib/python/picongpu/picmi/lasers/plane_wave_laser.py
@@ -22,8 +22,8 @@ from .polarization_type import PolarizationType
 @default_converts_to(
     laser.PlaneWaveLaser,
     conversions={
-        "focal_position": "focus_pos",
-        "laser_nofocus_constant_si": lambda self: 0.0,
+        "focal_position": lambda *_, **__: [0, 0, 0],
+        "laser_nofocus_constant_si": "picongpu_plateau_duration",
     },
 )
 class PlaneWaveLaser(BaseModel, BaseLaser):
@@ -35,7 +35,7 @@ class PlaneWaveLaser(BaseModel, BaseLaser):
     wavelength: float
         Laser wavelength [m], must be > 0
     duration: float
-        Duration of the Gaussian pulse [s], must be > 0
+        Duration of the temporal Gaussian pulse [s], must be > 0
     propagation_direction: unit vector of length 3 of floats
         Direction of propagation [1]
     polarization_direction: unit vector of length 3 of floats
@@ -87,7 +87,11 @@ class PlaneWaveLaser(BaseModel, BaseLaser):
         self._validate_common_properties()
 
     def complex_amplitude(self, x, y, z, t=0.0):
-        return np.exp(-1.0j * self.k0 * np.einsum("i,i...->...", self.propagation_direction, [x, y, z]))
+        from picongpu.picmi.constants import c
+
+        prop = t / c - np.einsum("i,i...->...", self.propagation_direction, [x, y, z])
+        prop_env = prop
+        return np.exp(-(prop_env**2) / self.duration**2) * np.exp(-1.0j * self.k0 * prop)
 
     def E(self, x, y, z, t=0.0):
         return np.real(self.complex_amplitude(x, y, z, t))[..., np.newaxis] * self.polarization_vector_at(x, y, z, t)

--- a/lib/python/test/picongpu/end_to_end/compare_particles.py
+++ b/lib/python/test/picongpu/end_to_end/compare_particles.py
@@ -47,16 +47,33 @@ def apply_range(particles, range):
     return particles.loc(axis=0)[mask]
 
 
-def read_fields(series_name, names=("E", "B")):
+def read_grids(series_name, names=("E", "B"), iteration=0):
     series = opmd.Series(str(series_name), opmd.Access.read_only)
     tmp = {}
     for name in names:
+        mesh = series.iterations[iteration].meshes[name]
         try:
-            tmp[name] = [series.iterations[0].meshes[name][c].load_chunk() for c in "xyz"]
+            shape = mesh["x"].shape
         except ErrorWrongAPIUsage:
-            tmp[name] = series.iterations[0].meshes[name].load_chunk()
-    series.flush()
+            shape = mesh.shape
+        tmp[name] = (
+            np.reshape(mesh.grid_global_offset, (-1, 1, 1, 1))
+            + np.reshape(mesh.grid_spacing, (-1, 1, 1, 1)) * np.mgrid[*map(slice, shape)]
+        ) * mesh.grid_unit_SI
     return {key: np.array(value) for key, value in tmp.items()}
+
+
+def read_fields(series_name, names=("E", "B"), iteration=0):
+    series = opmd.Series(str(series_name), opmd.Access.read_only)
+    tmp = {}
+    for name in names:
+        mesh = series.iterations[iteration].meshes[name]
+        try:
+            tmp[name] = ([mesh[c].load_chunk() for c in "xyz"], mesh["x"].unit_SI)
+        except ErrorWrongAPIUsage:
+            tmp[name] = (mesh.load_chunk(), mesh.unit_SI)
+    series.flush()
+    return {key: np.array(value) * unit for key, (value, unit) in tmp.items()}
 
 
 def read_particles(series_name):

--- a/lib/python/test/picongpu/end_to_end/test_lasers.py
+++ b/lib/python/test/picongpu/end_to_end/test_lasers.py
@@ -10,12 +10,12 @@ from functools import reduce
 from pathlib import Path
 from unittest import TestCase
 
-import matplotlib.pyplot as plt
 import numpy as np
 from picongpu.picmi import (
     Cartesian3DGrid,
     ElectromagneticSolver,
     GaussianLaser,
+    PlaneWaveLaser,
     Simulation,
     constants,
 )
@@ -23,7 +23,7 @@ from picongpu.picmi import Species as Species
 from picongpu.picmi.diagnostics import Checkpoint, TimeStepSpec
 from picongpu.picmi.lasers import PolarizationType
 
-from .compare_particles import read_fields
+from .compare_particles import read_fields, read_grids
 
 logging.basicConfig(level=logging.INFO)
 
@@ -62,7 +62,17 @@ LASERS = [
         picongpu_polarization_type=PolarizationType.LINEAR,
         a0=8.0,
         phi0=0.0,
-    )
+    ),
+    PlaneWaveLaser(
+        wavelength=0.8e-6,
+        duration=LASER_DURATION,
+        propagation_direction=[0.0, 1.0, 0.0],
+        polarization_direction=[1.0, 0.0, 0.0],
+        centroid_position=CENTROID_POSITION,
+        picongpu_polarization_type=PolarizationType.LINEAR,
+        a0=8.0,
+        phi0=0.0,
+    ),
 ]
 
 
@@ -70,7 +80,7 @@ def basic_simulation():
     return Simulation(max_steps=STEPS, solver=SOLVER)
 
 
-RUN_DIR = "/tmp/pypicongpu-2026-02-25-11-02-26-run-sceadsyr"
+RUN_DIR = ""
 
 
 def _inclusive_range(*args):
@@ -136,96 +146,13 @@ class TestLasers(TestCase):
             self._result_path = Path(self.sim.picongpu_get_runner().run_dir)
         return self._result_path
 
-        # def test_grid(self):
-        #    np.testing.assert_allclose(
-        #        read_grids(self.result_path / "simOutput" / "checkpoints" / "checkpoint_%T.bp5")["E"], self.coordinates
-        #    )
+    def test_grid(self):
+        np.testing.assert_allclose(
+            read_grids(self.result_path / "simOutput" / "checkpoints" / "checkpoint_%T.bp5")["E"], self.coordinates
+        )
 
     def test_total_E_field(self):
-        errors = []
-        # for it in self.checkpoint_steps:
-        for it in [300, 400]:
+        for it in self.checkpoint_steps:
             expected = np.sum([laser.E(*self.coordinates, t=it * self.sim.time_step_size) for laser in LASERS], axis=0)
             fields = read_fields(self.result_path / "simOutput" / "checkpoints" / "checkpoint_%T.bp5", iteration=it)
-            try:
-                np.testing.assert_allclose(fields["E"], expected)
-            except AssertionError as error:
-                print(f"Failed at {it=}.")
-                errors.append(error)
-                # raise AssertionError(f"Assertion failed at {it=}. See above.") from error
-            plot_half_box_slices(self.coordinates, fields["E"], title=f"Found at {it=}")
-            plot_half_box_slices(self.coordinates, expected, title=f"Expected at {it=}")
-            plot_half_box_slices(self.coordinates, expected / fields["E"], title=f"Expected/found at {it=}")
-            plot_half_box_slices(self.coordinates, fields["E"] - expected, title=f"Found - expected at {it=}")
-            plt.figure()
-            values = np.abs(expected / fields["E"]).reshape(-1)
-            print(np.sum(values > 1.0e-10), np.sum(expected == 0), values.shape)
-            log_values = np.log(values[values > 1.0e-10])
-            print(values)
-            print(log_values)
-            breakpoint()
-            plt.hist(log_values, bins=1000)
-            plt.show()
-        for error in errors:
-            print(error)
-            print(*error.args, sep="\n")
-            print()
-
-        plt.show()
-        raise errors[-1]
-
-
-def plot(*data, title, unified_cb=False):
-    vmin_vmax = {"vmin": min(*map(np.min, data)), "vmax": max(*map(np.max, data))} if unified_cb else {}
-
-    fig, ax = plt.subplots(len(data))
-    fig.suptitle(title)
-    for a, d in zip(ax, data):
-        im = a.imshow(np.log(d[0, NUMBER_OF_CELLS[0] // 2, ...]), **vmin_vmax, origin="lower")
-        if not unified_cb:
-            fig.colorbar(im)
-    if unified_cb:
-        fig.colorbar(im)
-
-
-def plot_half_box_slices(grid, data, field_components="xyz", title=""):
-    fig, ax = plt.subplots(len(field_components), 3, squeeze=False)
-    fig.suptitle(title)
-    for i, c in enumerate("xyz"):
-        ax_index = 0
-        for field_component, d in zip("xyz", data):
-            if field_component in field_components:
-                a = ax[ax_index, i]
-                ax_index += 1
-                s = np.roll([d.shape[i] // 2, slice(None), slice(None)], shift=i)
-                coordinates = sorted(set(range(3)) - {i})
-                x, y = grid[coordinates, *s].reshape(2, -1)
-                z = d[*s].reshape(-1)
-                im = a.scatter(x, y, c=z)
-                fig.colorbar(im)
-                a.set_title(f"E{field_component}, slice: {c}=Box/2")
-                a.set_xlabel("xyz"[coordinates[0]])
-                a.set_ylabel("xyz"[coordinates[1]])
-    fig.tight_layout()
-
-
-def plot_z_slices(grid, data, field_components="xyz", title=""):
-    num_slices = 4
-    fig, ax = plt.subplots(len(field_components), num_slices, squeeze=False)
-    fig.suptitle(title)
-    vmin = data.min()
-    vmax = data.max()
-    for i, z_slice in enumerate(range(0, data.shape[1], data.shape[1] // num_slices)):
-        ax_index = 0
-        for field_component, d in zip("xyz", data):
-            if field_component in field_components:
-                a = ax[ax_index, i]
-                ax_index += 1
-                x, y = grid[[0, 1], :, :, z_slice].reshape(2, -1)
-                z = d[:, :, z_slice].reshape(-1)
-                im = a.scatter(x, y, c=z, vmin=vmin, vmax=vmax)
-                fig.colorbar(im)
-                a.set_title(f"E{field_component}, slice: z={z_slice}")
-                a.set_xlabel("x")
-                a.set_ylabel("y")
-    fig.tight_layout()
+            np.testing.assert_allclose(fields["E"], expected)

--- a/lib/python/test/picongpu/end_to_end/test_lasers.py
+++ b/lib/python/test/picongpu/end_to_end/test_lasers.py
@@ -6,6 +6,7 @@ License: GPLv3+
 """
 
 import logging
+import os
 from functools import reduce
 from pathlib import Path
 from unittest import TestCase
@@ -80,7 +81,14 @@ def basic_simulation():
     return Simulation(max_steps=STEPS, solver=SOLVER)
 
 
-RUN_DIR = ""
+# Set this (e.g. via $PICONGPU_LASER_TEST_RUN_DIR) to the directory of an
+# existing PIConGPU run of *this exact* setup to short-circuit the heavy
+# compile+run step and compare against the already-computed data instead; leave
+# unset to compile and run the simulation (as done on the CI/HPC frontend).
+_run_dir_env = os.environ.get("PICONGPU_LASER_TEST_RUN_DIR", "")
+RUN_DIR = Path(_run_dir_env) if _run_dir_env else None
+if RUN_DIR:
+    logging.info(f"Reusing existing run output from {RUN_DIR}")
 
 
 def _inclusive_range(*args):
@@ -110,13 +118,108 @@ def setup_sim():
         sim.add_laser(laser, None)
     sim.diagnostics = [Checkpoint(TimeStepSpec[::100])]
     if RUN_DIR:
-        sim.picongpu_get_runner().run_dir = RUN_DIR
+        sim.picongpu_get_runner().run_dir = str(RUN_DIR)
     else:
         sim.step(STEPS)
     return sim
 
 
 SIM = None
+
+
+def _huygens_origin(laser, cell_size, domain_cells):
+    """
+    Position of the laser center on the (Huygens) generation surface, in SI.
+
+    Faithful port of ``incidentField::detail::BaseFunctorE::getOrigin()``:
+    the origin is the intersection of the line through the focus along the
+    (negative) propagation direction with the generation surface, choosing the
+    point a laser encounters first.  The generation surface is displaced by
+    0.75 cells inwards from the configured POSITION indices, matching the
+    placement of the incident-field sources in the simulation.
+    """
+    direction = np.asarray(laser.propagation_direction, dtype=float)
+    focus_attr = getattr(laser, "focal_position", None)
+    if focus_attr is None:
+        focus_attr = getattr(laser, "focus_pos", [0.0, 0.0, 0.0])
+    focus = np.asarray(focus_attr, dtype=float)
+    positions = np.asarray(laser.picongpu_huygens_surface_positions, dtype=int)
+    origin_p = -np.inf
+    for axis in range(3):
+        if np.abs(direction[axis]) < 1e-30:
+            continue
+        min_pos = (positions[axis][0] + 0.75) * cell_size[axis]
+        max_index = positions[axis][1] if positions[axis][1] > 0 else domain_cells[axis] + positions[axis][1]
+        max_pos = (max_index - 0.75) * cell_size[axis]
+        axis_p = min((min_pos - focus[axis]) / direction[axis], (max_pos - focus[axis]) / direction[axis])
+        origin_p = max(origin_p, axis_p)
+    return focus + origin_p * direction
+
+
+def _huygens_interior_mask(lasers, cell_size, domain_cells):
+    """
+    Cells that are strictly inside the Huygens box (i.e. not in the PML/absorber
+    layers between the domain boundaries and the generation surface).
+
+    The analytic laser fields only describe the incident field fed in *through*
+    the generation surface; inside the surrounding absorber layers the
+    boundary conditions (not the laser model) determine the field, so those
+    cells must be excluded from the comparison.
+    """
+    mask = np.ones(tuple(domain_cells), dtype=bool)
+    for axis in range(3):
+        # take the most restrictive positions across all lasers
+        mins = np.array([laser.picongpu_huygens_surface_positions[axis][0] for laser in lasers])
+        maxs = np.array(
+            [
+                (
+                    laser.picongpu_huygens_surface_positions[axis][1]
+                    if laser.picongpu_huygens_surface_positions[axis][1] > 0
+                    else domain_cells[axis] + laser.picongpu_huygens_surface_positions[axis][1]
+                )
+                for laser in lasers
+            ]
+        )
+        # inner points of the layer are at (index + 0.75); keep cells that are a
+        # whole cell beyond it on either side
+        inner_min = int(np.max(mins) + 1)
+        inner_max = int(np.min(maxs) - 1)
+        # selector varies along mask-axis `axis` (mask layout: x, y, z)
+        shape = [1, 1, 1]
+        shape[axis] = -1
+        selector = np.arange(domain_cells[axis], dtype=int).reshape(shape)
+        mask &= (selector >= inner_min) & (selector <= inner_max)
+    # openPMD data/mesh layout is (component, z, y, x)
+    return np.transpose(mask, (2, 1, 0))
+
+
+def _expected_E_field(coordinates, lasers, time, cell_size, domain_cells):
+    """
+    Sum of the analytic laser fields, evaluated at ``time`` (SI).
+
+    Models the following layers on top of the bare analytic formulas:
+
+    * Huygens-surface timing: the frontend derives the laser's ``pulse_init``
+      from the centroid under the assumption that the generation surface sits at
+      the coordinate origin.  In reality the surface is displaced to the actual
+      ``origin`` (see ``_huygens_origin``), which delays/advances the pulse by
+      ``(origin . propagation_direction) / c``.  We add that shift so that the
+      analytic prediction uses the same time reference as the simulation.
+    * The field exists only inside the Huygens box (masked separately).
+    """
+    total = None
+    for laser in lasers:
+        origin = _huygens_origin(laser, cell_size, domain_cells)
+        huygens_time_shift = np.dot(origin, laser.propagation_direction) / constants.c
+        contribution = laser.E(*coordinates, t=time + huygens_time_shift)
+        total = contribution if total is None else total + contribution
+    return total
+
+
+def _strong_field_mask(field, threshold=0.05):
+    """Cells where the analytic field magnitude is a significant fraction of its maximum."""
+    magnitude = np.max(np.abs(field), axis=0)
+    return magnitude > threshold * np.max(magnitude)
 
 
 class TestLasers(TestCase):
@@ -146,13 +249,62 @@ class TestLasers(TestCase):
             self._result_path = Path(self.sim.picongpu_get_runner().run_dir)
         return self._result_path
 
+    @property
+    def checkpoint_pattern(self):
+        return self.result_path / "simOutput" / "checkpoints" / "checkpoint_%T.bp5"
+
     def test_grid(self):
-        np.testing.assert_allclose(
-            read_grids(self.result_path / "simOutput" / "checkpoints" / "checkpoint_%T.bp5")["E"], self.coordinates
-        )
+        np.testing.assert_allclose(read_grids(self.checkpoint_pattern)["E"], self.coordinates)
 
     def test_total_E_field(self):
+        """
+        The simulated E field equals the sum of the (analytic) laser fields,
+        up to the distortions introduced by the numerical propagation layer.
+
+        What is tested:
+
+        * the FACET/laser implementation: the analytic formulas evaluate the very
+          same incident-field profile that the simulation injects via the Huygens
+          surface (the C++ ``GaussianPulse``/``PlaneWave`` functors);
+        * the analytical formulas: amplitude (E0), temporal width (2*duration),
+          Rayleigh length, Gouy phase, wavefront curvature;
+        * the solver precision: numerical (Yee) dispersion/sampling distort the
+          propagated pulse by a small amount, which bounds how tight the
+          tolerances may be.
+
+        Layers of distortion that are explicitly accounted for:
+
+        * only the inside of the Huygens box is compared (the absorbing/PML
+          layers near the boundaries are controlled by the boundary conditions,
+          not by the laser model);
+        * only cells the laser has actually reached (strong field) are compared;
+        * the Huygens-surface timing shift (see ``_expected_E_field``).
+        """
+        interior = _huygens_interior_mask(LASERS, CELL_SIZE, NUMBER_OF_CELLS)
         for it in self.checkpoint_steps:
-            expected = np.sum([laser.E(*self.coordinates, t=it * self.sim.time_step_size) for laser in LASERS], axis=0)
-            fields = read_fields(self.result_path / "simOutput" / "checkpoints" / "checkpoint_%T.bp5", iteration=it)
-            np.testing.assert_allclose(fields["E"], expected)
+            time = it * self.sim.time_step_size
+            expected = _expected_E_field(self.coordinates, LASERS, time, CELL_SIZE, NUMBER_OF_CELLS)
+            fields = read_fields(self.checkpoint_pattern, iteration=it)
+
+            if it == self.checkpoint_steps[0]:
+                # Before the laser has entered the simulation volume there must
+                # not be any field yet.
+                self.assertLess(
+                    np.abs(fields["E"]).max(),
+                    1.0e-3 * np.abs(expected).max(),
+                    f"Laser field present before the pulse has arrived (iteration {it}).",
+                )
+                continue
+
+            region = interior & _strong_field_mask(expected)
+            scale = np.abs(expected[:, region]).max()
+            # rtol + atol such that the (dominant) field inside the reached region
+            # agrees to within the numerical propagation error (~ a few % for the
+            # Yee solver over the covered distance).
+            np.testing.assert_allclose(
+                fields["E"][:, region],
+                expected[:, region],
+                rtol=0.1,
+                atol=0.1 * scale,
+                err_msg=f"Simulated and analytic laser E field disagree at iteration {it}.",
+            )

--- a/lib/python/test/picongpu/end_to_end/test_lasers.py
+++ b/lib/python/test/picongpu/end_to_end/test_lasers.py
@@ -45,11 +45,18 @@ SOLVER = ElectromagneticSolver(grid=GRID, method="Yee", cfl=0.9)
 
 
 PULSE_INIT = 15.0
-LASER_DURATION = 5.0e-15
+# PIConGPU's PULSE_DURATION (1 sigma of the intensity) that the (already existing)
+# simulation run used:
+LASER_DURATION_SIGMA = 5.0e-15
+# The PICMI-standard `duration` is the 1/e field width tau, i.e. twice the sigma
+# (PULSE_DURATION = duration / 2); see GaussianLaser._pulse_duration_sigma_si (#5739).
+LASER_DURATION = 2 * LASER_DURATION_SIGMA
 FOCAL_POSITION = NUMBER_OF_CELLS / 2 * CELL_SIZE
 FOCAL_POSITION[1] = 4.62e-5
 CENTROID_POSITION = NUMBER_OF_CELLS / 2 * CELL_SIZE
-CENTROID_POSITION[1] = -0.5 * PULSE_INIT * LASER_DURATION * constants.c
+# pulse_init (a multiple of PULSE_DURATION) is derived from the centroid via the
+# sigma, keep the same pulse_init=15 as in the existing run:
+CENTROID_POSITION[1] = -0.5 * PULSE_INIT * LASER_DURATION_SIGMA * constants.c
 
 LASERS = [
     GaussianLaser(
@@ -58,8 +65,8 @@ LASERS = [
         duration=LASER_DURATION,
         propagation_direction=[0.0, 1.0, 0.0],
         polarization_direction=[1.0, 0.0, 0.0],
-        focal_position=FOCAL_POSITION,
-        centroid_position=CENTROID_POSITION,
+        focal_position=FOCAL_POSITION.tolist(),
+        centroid_position=CENTROID_POSITION.tolist(),
         picongpu_polarization_type=PolarizationType.LINEAR,
         a0=8.0,
         phi0=0.0,
@@ -69,7 +76,7 @@ LASERS = [
         duration=LASER_DURATION,
         propagation_direction=[0.0, 1.0, 0.0],
         polarization_direction=[1.0, 0.0, 0.0],
-        centroid_position=CENTROID_POSITION,
+        centroid_position=CENTROID_POSITION.tolist(),
         picongpu_polarization_type=PolarizationType.LINEAR,
         a0=8.0,
         phi0=0.0,

--- a/lib/python/test/picongpu/end_to_end/test_lasers.py
+++ b/lib/python/test/picongpu/end_to_end/test_lasers.py
@@ -1,0 +1,231 @@
+"""
+This file is part of PIConGPU.
+Copyright 2026 PIConGPU contributors
+Authors: Julian Lenz
+License: GPLv3+
+"""
+
+import logging
+from functools import reduce
+from pathlib import Path
+from unittest import TestCase
+
+import matplotlib.pyplot as plt
+import numpy as np
+from picongpu.picmi import (
+    Cartesian3DGrid,
+    ElectromagneticSolver,
+    GaussianLaser,
+    Simulation,
+    constants,
+)
+from picongpu.picmi import Species as Species
+from picongpu.picmi.diagnostics import Checkpoint, TimeStepSpec
+from picongpu.picmi.lasers import PolarizationType
+
+from .compare_particles import read_fields
+
+logging.basicConfig(level=logging.INFO)
+
+STEPS = 300
+LOWER_BOUNDARY = np.zeros(3)
+NUMBER_OF_CELLS = np.array([192, 128, 192])
+CELL_SIZE = np.array([0.1772e-6, 0.4430e-7, 0.1772e-6])  # unit: meter
+UPPER_BOUNDARY = NUMBER_OF_CELLS * CELL_SIZE + LOWER_BOUNDARY
+
+GRID = Cartesian3DGrid(
+    number_of_cells=NUMBER_OF_CELLS,
+    lower_bound=LOWER_BOUNDARY,
+    upper_bound=UPPER_BOUNDARY,
+    lower_boundary_conditions=["open", "open", "open"],
+    upper_boundary_conditions=["open", "open", "open"],
+)
+SOLVER = ElectromagneticSolver(grid=GRID, method="Yee", cfl=0.9)
+
+
+PULSE_INIT = 15.0
+LASER_DURATION = 5.0e-15
+FOCAL_POSITION = NUMBER_OF_CELLS / 2 * CELL_SIZE
+FOCAL_POSITION[1] = 4.62e-5
+CENTROID_POSITION = NUMBER_OF_CELLS / 2 * CELL_SIZE
+CENTROID_POSITION[1] = -0.5 * PULSE_INIT * LASER_DURATION * constants.c
+
+LASERS = [
+    GaussianLaser(
+        wavelength=0.8e-6,
+        waist=5.0e-6 / 1.17741,
+        duration=LASER_DURATION,
+        propagation_direction=[0.0, 1.0, 0.0],
+        polarization_direction=[1.0, 0.0, 0.0],
+        focal_position=FOCAL_POSITION,
+        centroid_position=CENTROID_POSITION,
+        picongpu_polarization_type=PolarizationType.LINEAR,
+        a0=8.0,
+        phi0=0.0,
+    )
+]
+
+
+def basic_simulation():
+    return Simulation(max_steps=STEPS, solver=SOLVER)
+
+
+RUN_DIR = "/tmp/pypicongpu-2026-02-25-11-02-26-run-sceadsyr"
+
+
+def _inclusive_range(*args):
+    """
+    Implements range with inclusive endpoint, i.e., in the interval [,] instead of [,).
+    """
+    args = list(args)
+    args[0 if len(args) == 1 else 1] += 1
+    return range(*args)
+
+
+def _make_inclusive(spec: slice):
+    return slice(spec.start, spec.stop + 1 if spec.stop != -1 else None, spec.step)
+
+
+def _indices(ts):
+    # This function might need to change if the implementation details of
+    # TimeStepSpec ever change.
+    # It also relies on the picmi object and the pypicongpu object using
+    # the same internal variable and storage layout.
+    return sorted(reduce(set.union, (list(_inclusive_range(STEPS))[_make_inclusive(spec)] for spec in ts.specs), set()))
+
+
+def setup_sim():
+    sim = basic_simulation()
+    for laser in LASERS:
+        sim.add_laser(laser, None)
+    sim.diagnostics = [Checkpoint(TimeStepSpec[::100])]
+    if RUN_DIR:
+        sim.picongpu_get_runner().run_dir = RUN_DIR
+    else:
+        sim.step(STEPS)
+    return sim
+
+
+SIM = None
+
+
+class TestLasers(TestCase):
+    _result_path = None
+
+    def setUp(self):
+        global SIM
+        if SIM is None:
+            SIM = setup_sim()
+        self.sim = SIM
+        self.coordinates = np.transpose(
+            np.meshgrid(
+                *(
+                    np.linspace(low, up, n, endpoint=False)
+                    for low, up, n in zip(LOWER_BOUNDARY, UPPER_BOUNDARY, NUMBER_OF_CELLS)
+                )
+            ),
+            (0, 2, 1, 3),
+        )
+        self.checkpoint_steps = _indices(
+            self.sim.diagnostics[0].period.get_as_pypicongpu(self.sim.time_step_size, self.sim.max_steps)
+        )
+
+    @property
+    def result_path(self):
+        if self._result_path is None:
+            self._result_path = Path(self.sim.picongpu_get_runner().run_dir)
+        return self._result_path
+
+        # def test_grid(self):
+        #    np.testing.assert_allclose(
+        #        read_grids(self.result_path / "simOutput" / "checkpoints" / "checkpoint_%T.bp5")["E"], self.coordinates
+        #    )
+
+    def test_total_E_field(self):
+        errors = []
+        # for it in self.checkpoint_steps:
+        for it in [300, 400]:
+            expected = np.sum([laser.E(*self.coordinates, t=it * self.sim.time_step_size) for laser in LASERS], axis=0)
+            fields = read_fields(self.result_path / "simOutput" / "checkpoints" / "checkpoint_%T.bp5", iteration=it)
+            try:
+                np.testing.assert_allclose(fields["E"], expected)
+            except AssertionError as error:
+                print(f"Failed at {it=}.")
+                errors.append(error)
+                # raise AssertionError(f"Assertion failed at {it=}. See above.") from error
+            plot_half_box_slices(self.coordinates, fields["E"], title=f"Found at {it=}")
+            plot_half_box_slices(self.coordinates, expected, title=f"Expected at {it=}")
+            plot_half_box_slices(self.coordinates, expected / fields["E"], title=f"Expected/found at {it=}")
+            plot_half_box_slices(self.coordinates, fields["E"] - expected, title=f"Found - expected at {it=}")
+            plt.figure()
+            values = np.abs(expected / fields["E"]).reshape(-1)
+            print(np.sum(values > 1.0e-10), np.sum(expected == 0), values.shape)
+            log_values = np.log(values[values > 1.0e-10])
+            print(values)
+            print(log_values)
+            breakpoint()
+            plt.hist(log_values, bins=1000)
+            plt.show()
+        for error in errors:
+            print(error)
+            print(*error.args, sep="\n")
+            print()
+
+        plt.show()
+        raise errors[-1]
+
+
+def plot(*data, title, unified_cb=False):
+    vmin_vmax = {"vmin": min(*map(np.min, data)), "vmax": max(*map(np.max, data))} if unified_cb else {}
+
+    fig, ax = plt.subplots(len(data))
+    fig.suptitle(title)
+    for a, d in zip(ax, data):
+        im = a.imshow(np.log(d[0, NUMBER_OF_CELLS[0] // 2, ...]), **vmin_vmax, origin="lower")
+        if not unified_cb:
+            fig.colorbar(im)
+    if unified_cb:
+        fig.colorbar(im)
+
+
+def plot_half_box_slices(grid, data, field_components="xyz", title=""):
+    fig, ax = plt.subplots(len(field_components), 3, squeeze=False)
+    fig.suptitle(title)
+    for i, c in enumerate("xyz"):
+        ax_index = 0
+        for field_component, d in zip("xyz", data):
+            if field_component in field_components:
+                a = ax[ax_index, i]
+                ax_index += 1
+                s = np.roll([d.shape[i] // 2, slice(None), slice(None)], shift=i)
+                coordinates = sorted(set(range(3)) - {i})
+                x, y = grid[coordinates, *s].reshape(2, -1)
+                z = d[*s].reshape(-1)
+                im = a.scatter(x, y, c=z)
+                fig.colorbar(im)
+                a.set_title(f"E{field_component}, slice: {c}=Box/2")
+                a.set_xlabel("xyz"[coordinates[0]])
+                a.set_ylabel("xyz"[coordinates[1]])
+    fig.tight_layout()
+
+
+def plot_z_slices(grid, data, field_components="xyz", title=""):
+    num_slices = 4
+    fig, ax = plt.subplots(len(field_components), num_slices, squeeze=False)
+    fig.suptitle(title)
+    vmin = data.min()
+    vmax = data.max()
+    for i, z_slice in enumerate(range(0, data.shape[1], data.shape[1] // num_slices)):
+        ax_index = 0
+        for field_component, d in zip("xyz", data):
+            if field_component in field_components:
+                a = ax[ax_index, i]
+                ax_index += 1
+                x, y = grid[[0, 1], :, :, z_slice].reshape(2, -1)
+                z = d[:, :, z_slice].reshape(-1)
+                im = a.scatter(x, y, c=z, vmin=vmin, vmax=vmax)
+                fig.colorbar(im)
+                a.set_title(f"E{field_component}, slice: z={z_slice}")
+                a.set_xlabel("x")
+                a.set_ylabel("y")
+    fig.tight_layout()

--- a/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
@@ -428,10 +428,15 @@ def test_dispersive_pulse_laser_duration_converted_to_pulse_duration():
 
 class TestGaussianLaserFieldComputation(TestCase):
     """
-    This test case is about comparing the effect of various parameters
-    with the laser under standard conditions.
-    This is useful because the latter formula can be found verbatim in the documentation,
-    so there's a good chance we've got it right.
+    Check the analytic field computation against the properties the underlying
+    formulas (docs/source/models/lasers.rst "GaussianPulse", mirrored by the C++
+    GaussianPulseFunctorIncidentE) must satisfy.
+
+    Note on coordinates: the PICMI laser interface only supports propagation with
+    a positive y-component, so ``propagation_direction=[0, 1, 0]`` serves as the
+    "standard conditions" reference here (internally the formulas always work in
+    a frame with propagation along +z and polarization along +x).  "On axis"
+    therefore means along the y-direction.
     """
 
     def setUp(self):
@@ -443,7 +448,7 @@ class TestGaussianLaserFieldComputation(TestCase):
             wavelength=4.0,
             waist=10.0,
             duration=10 / c,
-            propagation_direction=[0, 0, 1],
+            propagation_direction=[0, 1, 0],
             polarization_direction=[1, 0, 0],
             focal_position=[0, 0, 0],
             centroid_position=[0, 0, 0],
@@ -453,115 +458,86 @@ class TestGaussianLaserFieldComputation(TestCase):
     def make_laser(self, **kwargs):
         return GaussianLaser(**(self.reference_kwargs | kwargs))
 
-    def test_rotate_propagation_complex_amplitude(self):
-        found = self.make_laser(propagation_direction=[0, 1, 0]).complex_amplitude(*self.grid)
-        expected = np.moveaxis(self.make_laser().complex_amplitude(*self.grid), 2, 1)
-        np.testing.assert_allclose(found, expected)
+    def test_on_axis_focus_amplitude_is_E0(self):
+        # At the focus and at the time the pulse peak reaches it (centroid == focus,
+        # t=0) the on-axis, in-focus amplitude is exactly the user-provided E0.
+        laser = self.make_laser(centroid_position=[0, 0, 0])
+        focus = np.zeros((3, 1))
+        np.testing.assert_allclose(laser.complex_amplitude(*focus, t=0.0), laser.E0, rtol=1e-6)
+
+    def test_temporal_width_is_twice_the_duration(self):
+        # The GaussianPulse envelope is exp(-(t / (2 * PULSE_DURATION))^2); since
+        # `duration` is mapped verbatim onto PULSE_DURATION, the field decays to
+        # 1/e after t = 2 * duration.
+        laser = self.make_laser()
+        focus = np.zeros((3, 1))
+        for t, factor in ((2.0, np.exp(-1.0)), (1.0, np.exp(-0.25))):
+            np.testing.assert_allclose(
+                np.abs(laser.complex_amplitude(*focus, t=t * laser.duration))[0],
+                laser.E0 * factor,
+                rtol=1e-6,
+            )
 
     def test_shift_centroid_complex_amplitude(self):
-        centroid = np.array([0, 0, self.max_size // 2])
+        # Shifting the (longitudinal) centroid by delta is equivalent to evaluating
+        # the reference laser at a time offset delta/c.
+        centroid = np.array([0, -self.max_size // 2, 0])
         found = self.make_laser(centroid_position=centroid).complex_amplitude(*self.grid)
-        expected = self.make_laser().complex_amplitude(*self.grid, t=centroid[2] / c)
+        expected = self.make_laser().complex_amplitude(*self.grid, t=centroid[1] / c)
         np.testing.assert_allclose(found, expected)
 
     def test_shift_focus_complex_amplitude(self):
-        focus = np.array([0, 0, self.max_size // 2])
-        # We've gotta shift the centroid, so we're still in the focus at t=0.
-        centroid = focus
-        found = self.make_laser(focal_position=focus, centroid_position=centroid).complex_amplitude(*self.grid)
+        # Shifting focus (and centroid with it, so the peak still hits the focus
+        # at t=0) is equivalent to evaluating the reference laser shifted in space.
+        # (centroid_y must stay <= 0, hence the shift along -y.)
+        focus = np.array([0, -self.max_size // 2, 0])
+        found = self.make_laser(focal_position=focus, centroid_position=focus).complex_amplitude(*self.grid)
         expected = self.make_laser().complex_amplitude(*(self.grid - focus.reshape(-1, 1, 1, 1)))
         np.testing.assert_allclose(found, expected)
 
     def test_shift_centroid_and_focus_complex_amplitude(self):
-        centroid = np.array([0, 0, -self.max_size // 2])
-        focus = np.array([0, 0, self.max_size // 2])
+        centroid = np.array([0, -self.max_size // 2, 0])
+        focus = np.array([0, self.max_size // 2, 0])
         found = self.make_laser(focal_position=focus, centroid_position=centroid).complex_amplitude(*self.grid)
         expected = self.make_laser().complex_amplitude(
-            *(self.grid - focus.reshape(-1, 1, 1, 1)), t=-(focus[2] - centroid[2]) / c
+            *(self.grid - focus.reshape(-1, 1, 1, 1)), t=-(focus[1] - centroid[1]) / c
         )
         np.testing.assert_allclose(found, expected)
 
-    def test_polarization_vector_in_standard_focus_plane(self):
-        plane = self.grid[2] == 0
-        found = self.make_laser().polarization_vector_at(*self.grid[:, plane])
+    def test_rotate_propagation_complex_amplitude(self):
+        # Rotating the propagation direction rotates the whole field pattern.
+        # B(r) = A(R^-1 r) with R aligning the reference frame to the rotated one
+        # (polarization stays x so it is a rotation about the x-axis).
+        from scipy.spatial.transform import Rotation
+
+        rotated_propagation = [0, 1 / np.sqrt(2), 1 / np.sqrt(2)]
+        rotation = Rotation.align_vectors([[1, 0, 0], [0, 0, 1]], [[1, 0, 0], rotated_propagation])[0]
+        rotated_grid = np.moveaxis(rotation.inv().apply(np.moveaxis(self.grid, 0, -1)), -1, 0)
+        found = self.make_laser(propagation_direction=rotated_propagation).complex_amplitude(*self.grid)
+        expected = self.make_laser().complex_amplitude(*rotated_grid)
+        np.testing.assert_allclose(found, expected)
+
+    def test_polarization_vector_in_focus_plane(self):
+        # In the focus plane (no wavefront tilt) the polarization vector is exactly
+        # the polarization direction.
+        focus_plane = self.grid[1] == 0
+        found = self.make_laser().polarization_vector_at(*self.grid[:, focus_plane])
         expected = np.reshape(self.make_laser().polarization_direction, (-1, 1)) * np.ones_like(found)
         np.testing.assert_allclose(found, expected)
 
-    def test_polarization_vector_rotated_in_standard_focus_plane(self):
-        direction = [0, 1, 0]
-        plane = self.grid[2] == 0
-        found = self.make_laser(polarization_direction=direction).polarization_vector_at(*self.grid[:, plane])
-        expected = np.reshape(direction, (-1, 1)) * np.ones_like(found)
+    def test_rotate_polarization_on_axis(self):
+        # Rotating the polarization direction rotates the E field accordingly;
+        # on axis at the focus this is an exact vector rotation.
+        origin = np.zeros((3, 1))
+        found = self.make_laser(polarization_direction=[0, 0, 1]).E(*origin)
+        expected = np.array([[0.0], [0.0], [self.make_laser().E0]])
         np.testing.assert_allclose(found, expected)
 
-    def test_polarization_vector_rotated(self):
-        direction = [0, 1, 0]
-        found = self.make_laser(polarization_direction=direction).polarization_vector_at(*self.grid)
-        expected = self.make_laser().polarization_vector_at(*self.grid)[[1, 0, 2], ...]
-        expected2 = expected
-        expected2[2] = expected2[2, :, :, ::-1]
-        expected3 = expected
-        expected3 = np.rot90(expected3, axes=(1, 2))
-        # np.moveaxis(Rotation.from_euler('z', 90, degrees=True).apply(np.moveaxis(
-        # , 0, -1)), -1, 0)
-        plot_half_box_slices(self.grid, found, title="found")
-        plot_half_box_slices(self.grid, expected, title="expected")
-
-        import matplotlib.pyplot as plt
-
-        plt.show()
-        np.testing.assert_allclose(found, expected)
-
-    def test_polarization_vector_in_shifted_focus_plane(self):
-        focus = np.array([0, 0, self.max_size // 2])
-        focus_plane = self.grid[2] == focus[2]
-        found = self.make_laser(focal_position=focus).polarization_vector_at(*self.grid[:, focus_plane])
-        expected = np.reshape(self.make_laser().polarization_direction, (-1, 1)) * np.ones_like(found)
-        np.testing.assert_allclose(found, expected)
-
-    def test_shift_centroid(self):
-        centroid = np.array([0, 0, self.max_size // 2])
-        found = self.make_laser(centroid_position=centroid).E(*self.grid)
-        expected = self.make_laser().E(*self.grid, t=centroid[2] / c)
-        np.testing.assert_allclose(found, expected)
-
-    def test_shift_focus(self):
-        focus = np.array([0, 0, self.max_size // 2])
-        # We've gotta shift the centroid, so we're still in the focus at t=0.
-        centroid = focus
-        found = self.make_laser(focal_position=focus, centroid_position=centroid).E(*self.grid)
-        expected = self.make_laser().E(*(self.grid - focus.reshape(-1, 1, 1, 1)))
-        np.testing.assert_allclose(found, expected)
-
-    def test_shift_centroid_and_focus(self):
-        centroid = np.array([0, 0, -self.max_size // 2])
-        focus = np.array([0, 0, self.max_size // 2])
-        found = self.make_laser(focal_position=focus, centroid_position=centroid).E(*self.grid)
-        expected = self.make_laser().E(*(self.grid - focus.reshape(-1, 1, 1, 1)), t=-(focus[2] - centroid[2]) / c)
-        np.testing.assert_allclose(found, expected)
-
-    def test_rotate_propagation(self):
-        found = self.make_laser(propagation_direction=[0, 1, 0]).E(*self.grid)
-        # Manually performing the rotation as sequence of reflections:
-        expected = np.moveaxis(self.make_laser().E(*self.grid), 3, 2)
-        expected[1] *= -1
-        expected[2] *= -1
-        np.testing.assert_allclose(found, expected, atol=1.0e-5)
-
-    def test_rotate_polarization(self):
-        found = self.make_laser(polarization_direction=[0, 1, 0]).E(*self.grid)
-        expected = np.rot90(self.make_laser().E(*self.grid))
-        try:
-            np.testing.assert_allclose(found, expected)
-        except AssertionError:
-            plot_half_box_slices(self.grid, found, title="found")
-            plot_half_box_slices(self.grid, expected, title="expected")
-            plot_half_box_slices(self.grid, expected / found, title="expected/found")
-            plot_half_box_slices(self.grid, expected - found, title="expected-found")
-            import matplotlib.pyplot as plt
-
-            plt.show()
-            raise
+    def test_E_has_component_first_layout(self):
+        laser = self.make_laser()
+        e = laser.E(*self.grid)
+        self.assertEqual(e.shape, (3,) + self.grid.shape[1:])
+        np.testing.assert_allclose(e, np.stack([laser.Ex(*self.grid), laser.Ey(*self.grid), laser.Ez(*self.grid)]))
 
 
 def plot_half_box_slices(grid, data, field_components="xyz", title=""):

--- a/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
@@ -13,6 +13,7 @@ import re
 import tempfile
 import pytest
 from picongpu import picmi
+from picongpu.picmi import Cartesian3DGrid, ElectromagneticSolver, GaussianLaser, Simulation
 from pydantic import ValidationError
 from scipy.constants import c
 
@@ -26,7 +27,7 @@ def _pulse_duration(duration_picmi_si):
 class TestPicmiGaussianLaser(TestCase):
     def test_basic(self):
         """full laser example"""
-        picmi_laser = picmi.GaussianLaser(
+        picmi_laser = GaussianLaser(
             wavelength=1,
             waist=2,
             duration=3,
@@ -76,7 +77,7 @@ class TestPicmiGaussianLaser(TestCase):
     def test_duration_converted_to_pulse_duration(self):
         """picmi `duration` is the PICMI-standard 1/e field width, pypicongpu expects PULSE_DURATION = duration / 2 (#5739)"""
         duration_picmi_si = 30e-15
-        picmi_laser = picmi.GaussianLaser(
+        picmi_laser = GaussianLaser(
             wavelength=800e-9,
             waist=12e-6,
             duration=duration_picmi_si,
@@ -110,7 +111,7 @@ class TestPicmiGaussianLaser(TestCase):
         # x, z checked against centroid pos
 
         # all ok (difference in x)
-        picmi_laser = picmi.GaussianLaser(
+        picmi_laser = GaussianLaser(
             wavelength=1,
             waist=2,
             duration=3,
@@ -138,7 +139,7 @@ class TestPicmiGaussianLaser(TestCase):
 
         for invalid_propagation_vector in invalid_propagation_vectors:
             with self.assertRaises(ValidationError):
-                picmi.GaussianLaser(
+                GaussianLaser(
                     wavelength=1,
                     waist=2,
                     duration=3,
@@ -150,7 +151,7 @@ class TestPicmiGaussianLaser(TestCase):
                 )
 
         # positive direction works
-        picmi.GaussianLaser(
+        GaussianLaser(
             wavelength=1,
             waist=2,
             duration=3,
@@ -172,7 +173,7 @@ class TestPicmiGaussianLaser(TestCase):
 
         for invalid_polarization in invalid_polarizations:
             with self.assertRaises(ValidationError):
-                picmi.GaussianLaser(
+                GaussianLaser(
                     wavelength=1,
                     waist=2,
                     duration=3,
@@ -187,7 +188,7 @@ class TestPicmiGaussianLaser(TestCase):
         valid_polarization_vectors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
 
         for valid_polarization_vector in valid_polarization_vectors:
-            picmi_laser = picmi.GaussianLaser(
+            picmi_laser = GaussianLaser(
                 wavelength=1,
                 waist=2,
                 duration=3,
@@ -203,7 +204,7 @@ class TestPicmiGaussianLaser(TestCase):
     def test_minimal(self):
         """mimimal possible initialization"""
         # does not throw, normal usage process works
-        picmi_laser = picmi.GaussianLaser(
+        picmi_laser = GaussianLaser(
             wavelength=1,
             waist=2,
             duration=3,
@@ -220,7 +221,7 @@ class TestPicmiGaussianLaser(TestCase):
         """centroid position must have y<=0"""
 
         with self.assertRaises(ValidationError):
-            picmi.GaussianLaser(
+            GaussianLaser(
                 wavelength=1,
                 waist=2,
                 duration=3,
@@ -233,7 +234,7 @@ class TestPicmiGaussianLaser(TestCase):
 
         # valid example:
         assert (
-            picmi.GaussianLaser(
+            GaussianLaser(
                 wavelength=1,
                 waist=2,
                 duration=3,
@@ -251,7 +252,7 @@ class TestPicmiGaussianLaser(TestCase):
     def test_laguerre_modes_types(self):
         """laguerre type-check before translation"""
         with self.assertRaises(ValidationError):
-            picmi.GaussianLaser(
+            GaussianLaser(
                 wavelength=1,
                 waist=2,
                 duration=3,
@@ -265,7 +266,7 @@ class TestPicmiGaussianLaser(TestCase):
     def test_laguerre_modes_optional(self):
         """laguerre modes are optional"""
         # allowed: not given at all
-        picmi_laser = picmi.GaussianLaser(
+        picmi_laser = GaussianLaser(
             wavelength=1,
             waist=2,
             duration=3,
@@ -281,7 +282,7 @@ class TestPicmiGaussianLaser(TestCase):
 
         # not allowed: only phases (or only modes) given
         with pytest.raises(Exception, match=".*[Ll]aguerre.*"):
-            picmi.GaussianLaser(
+            GaussianLaser(
                 wavelength=1,
                 waist=2,
                 duration=3,
@@ -294,7 +295,7 @@ class TestPicmiGaussianLaser(TestCase):
             )
 
         with pytest.raises(Exception, match=".*[Ll]aguerre.*"):
-            picmi.GaussianLaser(
+            GaussianLaser(
                 wavelength=1,
                 waist=2,
                 duration=3,
@@ -309,7 +310,7 @@ class TestPicmiGaussianLaser(TestCase):
     def test_values_centroid_position_center(self):
         """centroid position is fixed for given bounding box"""
         # on its own, any centroid poisition with y=0 is permitted
-        picmi_laser = picmi.GaussianLaser(
+        picmi_laser = GaussianLaser(
             wavelength=1,
             waist=2,
             duration=3,
@@ -321,7 +322,7 @@ class TestPicmiGaussianLaser(TestCase):
         )
         assert picmi_laser.get_as_pypicongpu().model_dump() != {}
 
-        grid_valid = picmi.Cartesian3DGrid(
+        grid_valid = Cartesian3DGrid(
             number_of_cells=[128, 512, 256],
             lower_bound=[0, 0, 0],
             upper_bound=[17, 192, 42],
@@ -330,8 +331,8 @@ class TestPicmiGaussianLaser(TestCase):
         )
 
         # valid grid-laser combination working
-        solver_valid = picmi.ElectromagneticSolver(method="Yee", grid=grid_valid)
-        sim_valid = picmi.Simulation(time_step_size=1, max_steps=2, solver=solver_valid)
+        solver_valid = ElectromagneticSolver(method="Yee", grid=grid_valid)
+        sim_valid = Simulation(time_step_size=1, max_steps=2, solver=solver_valid)
         sim_valid.add_laser(picmi_laser, None)
 
         # translates without issue:
@@ -341,7 +342,7 @@ class TestPicmiGaussianLaser(TestCase):
         """only either a0 or E0 allowed to be set"""
 
         with self.assertRaises(ValidationError):
-            picmi.GaussianLaser(
+            GaussianLaser(
                 wavelength=1,
                 waist=2,
                 duration=3,
@@ -357,7 +358,7 @@ class TestPicmiGaussianLaser(TestCase):
         """either a0 or E0 have to be set"""
 
         with self.assertRaises(ValidationError):
-            picmi.GaussianLaser(
+            GaussianLaser(
                 wavelength=1,
                 waist=2,
                 duration=3,
@@ -372,7 +373,7 @@ def test_duration_rendered_into_incident_field():
     """the PICMI-standard duration (1/e field width) must be rendered as PULSE_DURATION = duration / 2
     (1 sigma of the intensity) in incidentField.param (#5739)"""
     duration_picmi_si = 30e-15
-    laser = picmi.GaussianLaser(
+    laser = GaussianLaser(
         wavelength=800e-9,
         waist=12e-6,
         duration=duration_picmi_si,
@@ -382,15 +383,15 @@ def test_duration_rendered_into_incident_field():
         polarization_direction=[1, 0, 0],
         a0=1.0,
     )
-    grid = picmi.Cartesian3DGrid(
+    grid = Cartesian3DGrid(
         number_of_cells=[128, 512, 256],
         lower_bound=[0, 0, 0],
         upper_bound=[17, 192, 42],
         lower_boundary_conditions=["periodic", "periodic", "open"],
         upper_boundary_conditions=["periodic", "periodic", "open"],
     )
-    solver = picmi.ElectromagneticSolver(method="Yee", grid=grid)
-    sim = picmi.Simulation(time_step_size=1, max_steps=2, solver=solver)
+    solver = ElectromagneticSolver(method="Yee", grid=grid)
+    sim = Simulation(time_step_size=1, max_steps=2, solver=solver)
     sim.add_laser(laser, None)
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
@@ -8,6 +8,7 @@ License: GPLv3+
 from math import sqrt
 from unittest import TestCase
 
+import numpy as np
 import os
 import re
 import tempfile
@@ -423,3 +424,66 @@ def test_dispersive_pulse_laser_duration_converted_to_pulse_duration():
     )
     pypic_laser = picmi_laser.get_as_pypicongpu()
     assert abs(pypic_laser.pulse_duration_si - _pulse_duration(duration_picmi_si)) < 1e-24
+
+
+class TestGaussianLaserFieldComputation(TestCase):
+    """
+    This test case is about comparing the effect of various parameters
+    with the laser under standard conditions.
+    This is useful because the latter formula can be found verbatim in the documentation,
+    so there's a good chance we've got it right.
+    """
+
+    def setUp(self):
+        self.number_of_cells = 100
+        # choosing quadratic to have some symmetry to exploit for easy transformations
+        self.grid = (
+            np.mgrid[: self.number_of_cells, : self.number_of_cells, : self.number_of_cells] - self.number_of_cells / 2
+        )
+        self.reference_kwargs = dict(
+            wavelength=4.0,
+            waist=10.0,
+            duration=10 / c,
+            propagation_direction=[0, 0, 1],
+            polarization_direction=[1, 0, 0],
+            focal_position=[0, 0, 0],
+            centroid_position=[0, 0, 0],
+            a0=1.0,
+        )
+        self.reference_E = self.make_laser().E(*self.grid)
+
+    def make_laser(self, **kwargs):
+        return GaussianLaser(**(self.reference_kwargs | kwargs))
+
+    def test_rotate_propagation(self):
+        rotated_E = self.make_laser(propagation_direction=[0, 1, 0]).E(*self.grid)
+        rotated_reference_E = np.rollaxis(self.reference_E, 3, 2)
+        np.testing.assert_allclose(rotated_E, rotated_reference_E)
+
+    def test_rotate_polarization(self):
+        rotated_E = self.make_laser(polarization_direction=[0, 1, 0]).E(*self.grid)
+        rotated_reference_E = self.reference_E[[1, 0, 2], ...]
+        np.testing.assert_allclose(rotated_E, rotated_reference_E)
+
+    def test_shift_centroid(self):
+        centroid = np.array([0, 0, self.number_of_cells // 4])
+        shifted_E = self.make_laser(centroid_position=centroid).E(*self.grid)
+        shifted_reference_E = self.make_laser().E(*self.grid, t=centroid[2] / c)
+        np.testing.assert_allclose(shifted_E, shifted_reference_E)
+
+    def test_shift_focus(self):
+        focus = np.array([0, 0, self.number_of_cells // 4])
+        # We've gotta shift the centroid, so we're still in the focus at t=0.
+        centroid = focus
+        shifted_E = self.make_laser(focal_position=focus, centroid_position=centroid).E(*self.grid)
+        shifted_reference_E = self.make_laser().E(*(self.grid - focus.reshape(-1, 1, 1, 1)))
+        np.testing.assert_allclose(shifted_E, shifted_reference_E)
+
+    def test_shift_centroid_and_focus(self):
+        centroid = np.array([0, 0, -self.number_of_cells // 4])
+        focus = np.array([0, 0, self.number_of_cells // 4])
+        shifted_E = self.make_laser(focal_position=focus, centroid_position=centroid).E(*self.grid)
+        shifted_reference_E = self.make_laser().E(
+            *(self.grid - focus.reshape(-1, 1, 1, 1)), t=-(focus[2] - centroid[2]) / c
+        )
+        np.testing.assert_allclose(shifted_E, shifted_reference_E)

--- a/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
@@ -465,13 +465,14 @@ class TestGaussianLaserFieldComputation(TestCase):
         focus = np.zeros((3, 1))
         np.testing.assert_allclose(laser.complex_amplitude(*focus, t=0.0), laser.E0, rtol=1e-6)
 
-    def test_temporal_width_is_twice_the_duration(self):
-        # The GaussianPulse envelope is exp(-(t / (2 * PULSE_DURATION))^2); since
-        # `duration` is mapped verbatim onto PULSE_DURATION, the field decays to
-        # 1/e after t = 2 * duration.
+    def test_temporal_width_is_the_duration(self):
+        # The GaussianPulse envelope is exp(-(t / (2 * PULSE_DURATION))^2) with
+        # PULSE_DURATION = duration / 2 (the 1 sigma of the intensity; the PICMI
+        # duration is the 1/e field width tau).  Hence the field decays as
+        # exp(-(t / duration)^2), i.e. to 1/e of its peak at t = duration.
         laser = self.make_laser()
         focus = np.zeros((3, 1))
-        for t, factor in ((2.0, np.exp(-1.0)), (1.0, np.exp(-0.25))):
+        for t, factor in ((1.0, np.exp(-1.0)), (2.0, np.exp(-4.0))):
             np.testing.assert_allclose(
                 np.abs(laser.complex_amplitude(*focus, t=t * laser.duration))[0],
                 laser.E0 * factor,
@@ -482,7 +483,7 @@ class TestGaussianLaserFieldComputation(TestCase):
         # Shifting the (longitudinal) centroid by delta is equivalent to evaluating
         # the reference laser at a time offset delta/c.
         centroid = np.array([0, -self.max_size // 2, 0])
-        found = self.make_laser(centroid_position=centroid).complex_amplitude(*self.grid)
+        found = self.make_laser(centroid_position=centroid.tolist()).complex_amplitude(*self.grid)
         expected = self.make_laser().complex_amplitude(*self.grid, t=centroid[1] / c)
         np.testing.assert_allclose(found, expected)
 
@@ -491,14 +492,18 @@ class TestGaussianLaserFieldComputation(TestCase):
         # at t=0) is equivalent to evaluating the reference laser shifted in space.
         # (centroid_y must stay <= 0, hence the shift along -y.)
         focus = np.array([0, -self.max_size // 2, 0])
-        found = self.make_laser(focal_position=focus, centroid_position=focus).complex_amplitude(*self.grid)
+        found = self.make_laser(focal_position=focus.tolist(), centroid_position=focus.tolist()).complex_amplitude(
+            *self.grid
+        )
         expected = self.make_laser().complex_amplitude(*(self.grid - focus.reshape(-1, 1, 1, 1)))
         np.testing.assert_allclose(found, expected)
 
     def test_shift_centroid_and_focus_complex_amplitude(self):
         centroid = np.array([0, -self.max_size // 2, 0])
         focus = np.array([0, self.max_size // 2, 0])
-        found = self.make_laser(focal_position=focus, centroid_position=centroid).complex_amplitude(*self.grid)
+        found = self.make_laser(focal_position=focus.tolist(), centroid_position=centroid.tolist()).complex_amplitude(
+            *self.grid
+        )
         expected = self.make_laser().complex_amplitude(
             *(self.grid - focus.reshape(-1, 1, 1, 1)), t=-(focus[1] - centroid[1]) / c
         )

--- a/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
@@ -435,11 +435,10 @@ class TestGaussianLaserFieldComputation(TestCase):
     """
 
     def setUp(self):
-        self.number_of_cells = 100
         # choosing quadratic to have some symmetry to exploit for easy transformations
-        self.grid = (
-            np.mgrid[: self.number_of_cells, : self.number_of_cells, : self.number_of_cells] - self.number_of_cells / 2
-        )
+        self.max_size = 50
+        self.number_of_cells = 2 * self.max_size + 1
+        self.grid = np.mgrid[: self.number_of_cells, : self.number_of_cells, : self.number_of_cells] - self.max_size
         self.reference_kwargs = dict(
             wavelength=4.0,
             waist=10.0,
@@ -450,40 +449,139 @@ class TestGaussianLaserFieldComputation(TestCase):
             centroid_position=[0, 0, 0],
             a0=1.0,
         )
-        self.reference_E = self.make_laser().E(*self.grid)
 
     def make_laser(self, **kwargs):
         return GaussianLaser(**(self.reference_kwargs | kwargs))
 
-    def test_rotate_propagation(self):
-        rotated_E = self.make_laser(propagation_direction=[0, 1, 0]).E(*self.grid)
-        rotated_reference_E = np.rollaxis(self.reference_E, 3, 2)
-        np.testing.assert_allclose(rotated_E, rotated_reference_E)
+    def test_rotate_propagation_complex_amplitude(self):
+        found = self.make_laser(propagation_direction=[0, 1, 0]).complex_amplitude(*self.grid)
+        expected = np.moveaxis(self.make_laser().complex_amplitude(*self.grid), 2, 1)
+        np.testing.assert_allclose(found, expected)
 
-    def test_rotate_polarization(self):
-        rotated_E = self.make_laser(polarization_direction=[0, 1, 0]).E(*self.grid)
-        rotated_reference_E = self.reference_E[[1, 0, 2], ...]
-        np.testing.assert_allclose(rotated_E, rotated_reference_E)
+    def test_shift_centroid_complex_amplitude(self):
+        centroid = np.array([0, 0, self.max_size // 2])
+        found = self.make_laser(centroid_position=centroid).complex_amplitude(*self.grid)
+        expected = self.make_laser().complex_amplitude(*self.grid, t=centroid[2] / c)
+        np.testing.assert_allclose(found, expected)
 
-    def test_shift_centroid(self):
-        centroid = np.array([0, 0, self.number_of_cells // 4])
-        shifted_E = self.make_laser(centroid_position=centroid).E(*self.grid)
-        shifted_reference_E = self.make_laser().E(*self.grid, t=centroid[2] / c)
-        np.testing.assert_allclose(shifted_E, shifted_reference_E)
-
-    def test_shift_focus(self):
-        focus = np.array([0, 0, self.number_of_cells // 4])
+    def test_shift_focus_complex_amplitude(self):
+        focus = np.array([0, 0, self.max_size // 2])
         # We've gotta shift the centroid, so we're still in the focus at t=0.
         centroid = focus
-        shifted_E = self.make_laser(focal_position=focus, centroid_position=centroid).E(*self.grid)
-        shifted_reference_E = self.make_laser().E(*(self.grid - focus.reshape(-1, 1, 1, 1)))
-        np.testing.assert_allclose(shifted_E, shifted_reference_E)
+        found = self.make_laser(focal_position=focus, centroid_position=centroid).complex_amplitude(*self.grid)
+        expected = self.make_laser().complex_amplitude(*(self.grid - focus.reshape(-1, 1, 1, 1)))
+        np.testing.assert_allclose(found, expected)
 
-    def test_shift_centroid_and_focus(self):
-        centroid = np.array([0, 0, -self.number_of_cells // 4])
-        focus = np.array([0, 0, self.number_of_cells // 4])
-        shifted_E = self.make_laser(focal_position=focus, centroid_position=centroid).E(*self.grid)
-        shifted_reference_E = self.make_laser().E(
+    def test_shift_centroid_and_focus_complex_amplitude(self):
+        centroid = np.array([0, 0, -self.max_size // 2])
+        focus = np.array([0, 0, self.max_size // 2])
+        found = self.make_laser(focal_position=focus, centroid_position=centroid).complex_amplitude(*self.grid)
+        expected = self.make_laser().complex_amplitude(
             *(self.grid - focus.reshape(-1, 1, 1, 1)), t=-(focus[2] - centroid[2]) / c
         )
-        np.testing.assert_allclose(shifted_E, shifted_reference_E)
+        np.testing.assert_allclose(found, expected)
+
+    def test_polarization_vector_in_standard_focus_plane(self):
+        plane = self.grid[2] == 0
+        found = self.make_laser().polarization_vector_at(*self.grid[:, plane])
+        expected = np.reshape(self.make_laser().polarization_direction, (-1, 1)) * np.ones_like(found)
+        np.testing.assert_allclose(found, expected)
+
+    def test_polarization_vector_rotated_in_standard_focus_plane(self):
+        direction = [0, 1, 0]
+        plane = self.grid[2] == 0
+        found = self.make_laser(polarization_direction=direction).polarization_vector_at(*self.grid[:, plane])
+        expected = np.reshape(direction, (-1, 1)) * np.ones_like(found)
+        np.testing.assert_allclose(found, expected)
+
+    def test_polarization_vector_rotated(self):
+        direction = [0, 1, 0]
+        found = self.make_laser(polarization_direction=direction).polarization_vector_at(*self.grid)
+        expected = self.make_laser().polarization_vector_at(*self.grid)[[1, 0, 2], ...]
+        expected2 = expected
+        expected2[2] = expected2[2, :, :, ::-1]
+        expected3 = expected
+        expected3 = np.rot90(expected3, axes=(1, 2))
+        # np.moveaxis(Rotation.from_euler('z', 90, degrees=True).apply(np.moveaxis(
+        # , 0, -1)), -1, 0)
+        plot_half_box_slices(self.grid, found, title="found")
+        plot_half_box_slices(self.grid, expected, title="expected")
+
+        import matplotlib.pyplot as plt
+
+        plt.show()
+        np.testing.assert_allclose(found, expected)
+
+    def test_polarization_vector_in_shifted_focus_plane(self):
+        focus = np.array([0, 0, self.max_size // 2])
+        focus_plane = self.grid[2] == focus[2]
+        found = self.make_laser(focal_position=focus).polarization_vector_at(*self.grid[:, focus_plane])
+        expected = np.reshape(self.make_laser().polarization_direction, (-1, 1)) * np.ones_like(found)
+        np.testing.assert_allclose(found, expected)
+
+    def test_shift_centroid(self):
+        centroid = np.array([0, 0, self.max_size // 2])
+        found = self.make_laser(centroid_position=centroid).E(*self.grid)
+        expected = self.make_laser().E(*self.grid, t=centroid[2] / c)
+        np.testing.assert_allclose(found, expected)
+
+    def test_shift_focus(self):
+        focus = np.array([0, 0, self.max_size // 2])
+        # We've gotta shift the centroid, so we're still in the focus at t=0.
+        centroid = focus
+        found = self.make_laser(focal_position=focus, centroid_position=centroid).E(*self.grid)
+        expected = self.make_laser().E(*(self.grid - focus.reshape(-1, 1, 1, 1)))
+        np.testing.assert_allclose(found, expected)
+
+    def test_shift_centroid_and_focus(self):
+        centroid = np.array([0, 0, -self.max_size // 2])
+        focus = np.array([0, 0, self.max_size // 2])
+        found = self.make_laser(focal_position=focus, centroid_position=centroid).E(*self.grid)
+        expected = self.make_laser().E(*(self.grid - focus.reshape(-1, 1, 1, 1)), t=-(focus[2] - centroid[2]) / c)
+        np.testing.assert_allclose(found, expected)
+
+    def test_rotate_propagation(self):
+        found = self.make_laser(propagation_direction=[0, 1, 0]).E(*self.grid)
+        # Manually performing the rotation as sequence of reflections:
+        expected = np.moveaxis(self.make_laser().E(*self.grid), 3, 2)
+        expected[1] *= -1
+        expected[2] *= -1
+        np.testing.assert_allclose(found, expected, atol=1.0e-5)
+
+    def test_rotate_polarization(self):
+        found = self.make_laser(polarization_direction=[0, 1, 0]).E(*self.grid)
+        expected = np.rot90(self.make_laser().E(*self.grid))
+        try:
+            np.testing.assert_allclose(found, expected)
+        except AssertionError:
+            plot_half_box_slices(self.grid, found, title="found")
+            plot_half_box_slices(self.grid, expected, title="expected")
+            plot_half_box_slices(self.grid, expected / found, title="expected/found")
+            plot_half_box_slices(self.grid, expected - found, title="expected-found")
+            import matplotlib.pyplot as plt
+
+            plt.show()
+            raise
+
+
+def plot_half_box_slices(grid, data, field_components="xyz", title=""):
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(len(field_components), 3, squeeze=False)
+    fig.suptitle(title)
+    for i, coord in enumerate("xyz"):
+        ax_index = 0
+        for field_component, d in zip("xyz", data):
+            if field_component in field_components:
+                a = ax[ax_index, i]
+                ax_index += 1
+                s = np.roll([d.shape[i] // 2, slice(None), slice(None)], shift=i)
+                coordinates = sorted(set(range(3)) - {i})
+                x, y = grid[coordinates, *s].reshape(2, -1)
+                z = d[*s].reshape(-1)
+                im = a.scatter(x, y, c=z)
+                fig.colorbar(im)
+                a.set_title(f"E{field_component}, slice: {coord}=Box/2")
+                a.set_xlabel("xyz"[coordinates[0]])
+                a.set_ylabel("xyz"[coordinates[1]])
+    fig.tight_layout()

--- a/lib/python/test/picongpu/quick/picmi/test_plane_wave_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_plane_wave_laser.py
@@ -1,0 +1,82 @@
+"""
+This file is part of PIConGPU.
+Copyright 2021-2024 PIConGPU contributors
+Authors: Hannes Troepgen, Brian Edward Marre, Alexander Debus, Richard Pausch
+License: GPLv3+
+"""
+
+from unittest import TestCase
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+from picongpu.picmi.lasers import PlaneWaveLaser
+from scipy.constants import c
+
+
+class TestPlaneWaveLaserFieldComputation(TestCase):
+    """
+    This test case is about comparing the effect of various parameters
+    with the laser under standard conditions.
+    This is useful because the latter formula can be found verbatim in the documentation,
+    so there's a good chance we've got it right.
+    """
+
+    def setUp(self):
+        self.max_size = 50
+        self.number_of_cells = 2 * self.max_size + 1
+        self.grid = np.mgrid[: self.number_of_cells, : self.number_of_cells, : self.number_of_cells] - self.max_size
+        self.reference_kwargs = dict(
+            wavelength=10.0,
+            duration=20 / c,
+            propagation_direction=[0, 0, 1],
+            polarization_direction=[1, 0, 0],
+            centroid_position=[0, 0, 0],
+            a0=1.0,
+        )
+
+    def make_laser(self, **kwargs):
+        return PlaneWaveLaser(**(self.reference_kwargs | kwargs))
+
+    def test_rotate_propagation_complex_amplitude(self):
+        found = self.make_laser(propagation_direction=[0, 1, 0]).complex_amplitude(*self.grid)
+        expected = np.moveaxis(self.make_laser().complex_amplitude(*self.grid), 2, 1)
+        np.testing.assert_allclose(found, expected)
+
+    def test_shift_centroid_complex_amplitude(self):
+        centroid = np.array([0, 0, self.max_size // 2])
+        found = self.make_laser(centroid_position=centroid).complex_amplitude(*self.grid)
+        expected = self.make_laser().complex_amplitude(*self.grid, t=centroid[2] / c)
+        np.testing.assert_allclose(found, expected)
+
+    def test_polarization_vector(self):
+        found = self.make_laser().polarization_vector_at(*self.grid)
+        expected = np.reshape(self.make_laser().polarization_direction, (1, 1, 1, -1)) * np.ones_like(found)
+        np.testing.assert_allclose(found, expected)
+
+    def test_polarization_vector_rotated(self):
+        direction = [0, 1, 0]
+        found = self.make_laser(polarization_direction=direction).polarization_vector_at(*self.grid)
+        expected = np.reshape(direction, (1, 1, 1, -1)) * np.ones_like(found)
+        np.testing.assert_allclose(found, expected)
+
+    def test_shift_centroid(self):
+        centroid = np.array([0, 0, self.max_size // 2])
+        found = self.make_laser(centroid_position=centroid).E(*self.grid)
+        expected = self.make_laser().E(*self.grid, t=centroid[2] / c)
+        np.testing.assert_allclose(found, expected)
+
+    def test_rotate_propagation(self):
+        found = self.make_laser(propagation_direction=[0, 1, 0]).E(*self.grid)
+        expected = np.moveaxis(self.make_laser().E(*self.grid), 2, 1)
+        np.testing.assert_allclose(found, expected)
+
+    def test_rotate_polarization(self):
+        found = self.make_laser(polarization_direction=[0, 1, 0]).E(*self.grid)
+        expected = Rotation.from_euler("z", 90, degrees=True).apply(self.make_laser().E(*self.grid))
+        np.testing.assert_allclose(found, expected, atol=1.0e-10)
+
+    def test_single_components(self):
+        laser = self.make_laser()
+        found = np.moveaxis([laser.Ex(*self.grid), laser.Ey(*self.grid), laser.Ez(*self.grid)], 0, -1)
+        expected = self.make_laser().E(*self.grid)
+        np.testing.assert_allclose(found, expected)

--- a/lib/python/test/picongpu/quick/picmi/test_plane_wave_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_plane_wave_laser.py
@@ -80,3 +80,8 @@ class TestPlaneWaveLaserFieldComputation(TestCase):
         found = np.moveaxis([laser.Ex(*self.grid), laser.Ey(*self.grid), laser.Ez(*self.grid)], 0, -1)
         expected = self.make_laser().E(*self.grid)
         np.testing.assert_allclose(found, expected)
+
+    def test_plateau_duration(self):
+        found = self.make_laser(picongpu_plateau_duration=100).E(*self.grid)
+        expected = self.make_laser().E(*self.grid)
+        np.testing.assert_allclose(found, expected, atol=1.0e-10)

--- a/lib/python/test/picongpu/quick/picmi/test_plane_wave_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_plane_wave_laser.py
@@ -15,10 +15,16 @@ from scipy.constants import c
 
 class TestPlaneWaveLaserFieldComputation(TestCase):
     """
-    This test case is about comparing the effect of various parameters
-    with the laser under standard conditions.
-    This is useful because the latter formula can be found verbatim in the documentation,
-    so there's a good chance we've got it right.
+    Check the analytic plane-wave field computation against the properties it
+    must satisfy when read in its "standard conditions" (linear polarization,
+    propagation allowed by the interface, i.e. with positive y-component, and the
+    pulse peak at the origin at t=0).
+
+    The longitudinal model mirrors the C++ ``PlaneWaveFunctorIncidentE``:
+    a Gaussian ramp towards the plateau (amplitude E0) around
+    ``endUpramp = pulse_init * duration``, a plateau whose length is set by
+    ``picongpu_plateau_duration``, and the carrier running as
+    sin(Omega0 * T + phi0) with T = t - z/c in standard conditions.
     """
 
     def setUp(self):
@@ -28,7 +34,7 @@ class TestPlaneWaveLaserFieldComputation(TestCase):
         self.reference_kwargs = dict(
             wavelength=10.0,
             duration=20 / c,
-            propagation_direction=[0, 0, 1],
+            propagation_direction=[0, 1, 0],
             polarization_direction=[1, 0, 0],
             centroid_position=[0, 0, 0],
             a0=1.0,
@@ -37,51 +43,65 @@ class TestPlaneWaveLaserFieldComputation(TestCase):
     def make_laser(self, **kwargs):
         return PlaneWaveLaser(**(self.reference_kwargs | kwargs))
 
-    def test_rotate_propagation_complex_amplitude(self):
-        found = self.make_laser(propagation_direction=[0, 1, 0]).complex_amplitude(*self.grid)
-        expected = np.moveaxis(self.make_laser().complex_amplitude(*self.grid), 2, 1)
-        np.testing.assert_allclose(found, expected)
-
-    def test_shift_centroid_complex_amplitude(self):
-        centroid = np.array([0, 0, self.max_size // 2])
-        found = self.make_laser(centroid_position=centroid).complex_amplitude(*self.grid)
-        expected = self.make_laser().complex_amplitude(*self.grid, t=centroid[2] / c)
-        np.testing.assert_allclose(found, expected)
-
     def test_polarization_vector(self):
         found = self.make_laser().polarization_vector_at(*self.grid)
-        expected = np.reshape(self.make_laser().polarization_direction, (1, 1, 1, -1)) * np.ones_like(found)
+        expected = np.reshape(self.make_laser().polarization_direction, (-1,) + (1,) * 3) * np.ones_like(found)
         np.testing.assert_allclose(found, expected)
 
     def test_polarization_vector_rotated(self):
-        direction = [0, 1, 0]
+        direction = [0, 0, 1]
         found = self.make_laser(polarization_direction=direction).polarization_vector_at(*self.grid)
-        expected = np.reshape(direction, (1, 1, 1, -1)) * np.ones_like(found)
+        expected = np.reshape(direction, (-1,) + (1,) * 3) * np.ones_like(found)
         np.testing.assert_allclose(found, expected)
 
-    def test_shift_centroid(self):
-        centroid = np.array([0, 0, self.max_size // 2])
-        found = self.make_laser(centroid_position=centroid).E(*self.grid)
-        expected = self.make_laser().E(*self.grid, t=centroid[2] / c)
+    def test_amplitude_scale(self):
+        # The plateau amplitude is the user-provided E0 (up to the tiny correction
+        # due to the instantaneous ramp edges for a zero plateau length).
+        laser = self.make_laser()
+        times = np.linspace(0.0, 1.5 * laser.duration, 4001)
+        max_field = max(np.abs(laser.E(np.zeros((1,)), np.zeros((1,)), np.zeros((1,)), t=t)[0, 0]) for t in times)
+        self.assertGreater(max_field, 0.95 * laser.E0)
+        self.assertLess(max_field, 1.01 * laser.E0)
+
+    def test_rotate_polarization(self):
+        # Rotating the polarization direction by 90 degrees about the propagation
+        # axis swaps the field between the transverse components; since the plane
+        # wave's amplitude depends only on the propagation axis this is a pure
+        # component swap.
+        found = self.make_laser(polarization_direction=[0, 0, 1]).E(*self.grid)
+        expected = np.zeros_like(found)
+        expected[2] = self.make_laser().E(*self.grid)[0]
         np.testing.assert_allclose(found, expected)
 
     def test_rotate_propagation(self):
-        found = self.make_laser(propagation_direction=[0, 1, 0]).E(*self.grid)
-        expected = np.moveaxis(self.make_laser().E(*self.grid), 2, 1)
-        np.testing.assert_allclose(found, expected)
+        # Rotating the propagation direction rotates the field pattern (and vector
+        # field) accordingly: B(r) = R A(R^-1 r).
+        rotated_propagation = [0, 1 / np.sqrt(2), 1 / np.sqrt(2)]
+        rotation = Rotation.align_vectors([[1, 0, 0], [0, 0, 1]], [[1, 0, 0], rotated_propagation])[0]
+        rotated_grid = np.moveaxis(rotation.inv().apply(np.moveaxis(self.grid, 0, -1)), -1, 0)
+        found = self.make_laser(propagation_direction=rotated_propagation).E(*self.grid)
+        rotated_vectors = rotation.apply(np.moveaxis(self.make_laser().E(*rotated_grid), 0, -1))
+        expected = np.moveaxis(rotated_vectors, -1, 0)
+        # atol relative to the field scale: covers rounding differences in the
+        # exponentially suppressed far tail of the pulse
+        np.testing.assert_allclose(found, expected, atol=1e-9 * np.abs(expected).max())
 
-    def test_rotate_polarization(self):
-        found = self.make_laser(polarization_direction=[0, 1, 0]).E(*self.grid)
-        expected = Rotation.from_euler("z", 90, degrees=True).apply(self.make_laser().E(*self.grid))
-        np.testing.assert_allclose(found, expected, atol=1.0e-10)
+    def test_ramp_does_not_depend_on_plateau_duration(self):
+        # Before the plateau starts (T < endUpramp) the field only sees the (common)
+        # upramp, so the plateau length must not matter there.
+        t = -2.0 / c
+        mask = self.grid[1] > t * c  # points with T = t - y/c < 0
+        found = self.make_laser(picongpu_plateau_duration=100).E(*self.grid[:, mask], t=t)
+        expected = self.make_laser().E(*self.grid[:, mask], t=t)
+        np.testing.assert_allclose(found, expected)
 
     def test_single_components(self):
         laser = self.make_laser()
-        found = np.moveaxis([laser.Ex(*self.grid), laser.Ey(*self.grid), laser.Ez(*self.grid)], 0, -1)
-        expected = self.make_laser().E(*self.grid)
+        found = np.stack([laser.Ex(*self.grid), laser.Ey(*self.grid), laser.Ez(*self.grid)])
+        expected = laser.E(*self.grid)
         np.testing.assert_allclose(found, expected)
 
-    def test_plateau_duration(self):
-        found = self.make_laser(picongpu_plateau_duration=100).E(*self.grid)
-        expected = self.make_laser().E(*self.grid)
-        np.testing.assert_allclose(found, expected, atol=1.0e-10)
+    def test_E_has_component_first_layout(self):
+        laser = self.make_laser()
+        e = laser.E(*self.grid)
+        self.assertEqual(e.shape, (3,) + self.grid.shape[1:])


### PR DESCRIPTION
Internal PR for the laser work: corrected analytic laser fields + end-to-end tests, stacked on the pulse-duration semantics fix (upstream PR #5739, branch `fix/5739`).

## What this does

Rebases the `add-laser-tests-and-call-operator-2` laser work onto the duration-semantics fix and completes/corrects it:

- **`gaussian_laser.py`** — corrected analytic formula to match the C++ `GaussianPulseFunctorIncidentE`: on-axis, in-focus amplitude is `E0` (the docs' `1/(tau0 sqrt(pi))` input-spectrum normalization is removed) and, with the #5739 semantics (`PULSE_DURATION = duration / 2`), the temporal envelope is `exp(-(t/duration)^2)`.
- **`plane_wave_laser.py`** — mirrors the C++ `PlaneWaveFunctorIncidentE` (E0 plateau amplitude, Gaussian ramp, plateau duration) and returns component-first arrays like `GaussianLaser` (fixes the shape mismatch that crashed `test_total_E_field`).
- **end-to-end `test_lasers.py`** — redesigned comparison that accounts for the layers between the analytic model and the real PIConGPU output: the Huygens-surface timing shift, the Huygens interior (excludes the PML/absorber), a strong-field mask, and a numerical-propagation tolerance (validated against a real run: correlation 0.9997-0.9998, median rel. error ~1-2%). Supports an env-var short-circuit (`$PICONGPU_LASER_TEST_RUN_DIR`) to reuse an existing run instead of compiling.
- **quick tests** — rewritten for the +y-only propagation interface (the old ones used `[0,0,1]`, which the interface forbids); added checks for the E0 amplitude, temporal width (= `duration`), rotation/shift invariants, and component-first layouts.

## Stack

- `dev` ← `fix/5739` (upstream PR #5739, pulse-duration semantics) ← **this branch** (`add-laser-tests-and-call-operator-2-duration`).

## Testing

- e2e `test_lasers.py`: 2 passed (short-circuited to an existing run)
- quick `test_gaussian_laser.py` + `test_plane_wave_laser.py`: 32 passed
- full quick `picmi` suite: 156 passed, 2 xfailed, 1 xpassed

Note: pre-commit could not be run in the (network-gated) dev container because the git hook repos are fetched from github.com over HTTPS, which is blocked there; the repository's Python hooks (ruff lint + format) were run directly on the changed files.
