### PR TITLE
Use PICMI-standard laser duration (1/e field width) in Gaussian lasers (internal mirror of #5739)

### DIFF
--- a/lib/python/picongpu/picmi/lasers/base_laser.py
+++ b/lib/python/picongpu/picmi/lasers/base_laser.py
@@ -12,6 +12,23 @@ import numpy as np
 from .. import constants
 
 
+def picmi_laser_duration_to_pulse_duration(duration_picmi_si):
+    """Convert the PICMI-standard laser ``duration`` to the PIConGPU
+    ``PULSE_DURATION`` parameter.
+
+    The PICMI standard defines the Gaussian temporal envelope as
+    ``E ~ exp(-t^2 / duration^2)``, i.e. ``duration`` is the 1/e half width
+    of the electric-field amplitude (see ``PICMI_GaussianLaser``).
+    PIConGPU's Gaussian temporal envelope is
+    ``E ~ exp(-t^2 / (4 * PULSE_DURATION^2))`` (see ``GaussianPulse.hpp``),
+    i.e. ``PULSE_DURATION`` is the 1 sigma of the intensity (see
+    ``BaseParam.def``; ``DispersivePulse.hpp`` documents
+    ``tau_0 = 2 * PULSE_DURATION``). Matching the two envelopes gives
+    ``duration = 2 * PULSE_DURATION``, hence ``PULSE_DURATION = duration / 2``.
+    """
+    return duration_picmi_si / 2.0
+
+
 def scalarProduct(a: list[float], b: list[float]) -> float:
     return np.dot(a, b).tolist()
 
@@ -48,10 +65,23 @@ class BaseLaser:
             a0 = E0 / (constants.m_e * constants.c**2 * k0 / constants.q_e)
         return a0, E0
 
+    def _pulse_duration_sigma_si(self):
+        """Pulse duration in s, as the 1 sigma of a standard gaussian for the intensity (E^2).
+
+        This is the quantity PIConGPU's laser parameters use (``PULSE_DURATION_SI``
+        in ``incidentField.param``). Classes whose PICMI ``duration`` has different
+        semantics (e.g. the PICMI standard's 1/e field width, see GaussianLaser)
+        must override this to return the converted value.
+        """
+        return self.duration
+
     def _compute_pulse_init(self):
         pulse_init = (
-            -2.0 * self.centroid_position[1] / (self.propagation_direction[1] * constants.c) / self.duration
-        )  # unit: multiple of laser pulse duration
+            -2.0
+            * self.centroid_position[1]
+            / (self.propagation_direction[1] * constants.c)
+            / self._pulse_duration_sigma_si()
+        )  # unit: multiple of the laser pulse duration (1 sigma of the intensity)
         # @todo extend this to other propagation directions than +y
         if pulse_init < 3.0:
             logging.warning(

--- a/lib/python/picongpu/picmi/lasers/base_laser.py
+++ b/lib/python/picongpu/picmi/lasers/base_laser.py
@@ -12,23 +12,6 @@ import numpy as np
 from .. import constants
 
 
-def picmi_laser_duration_to_pulse_duration(duration_picmi_si):
-    """Convert the PICMI-standard laser ``duration`` to the PIConGPU
-    ``PULSE_DURATION`` parameter.
-
-    The PICMI standard defines the Gaussian temporal envelope as
-    ``E ~ exp(-t^2 / duration^2)``, i.e. ``duration`` is the 1/e half width
-    of the electric-field amplitude (see ``PICMI_GaussianLaser``).
-    PIConGPU's Gaussian temporal envelope is
-    ``E ~ exp(-t^2 / (4 * PULSE_DURATION^2))`` (see ``GaussianPulse.hpp``),
-    i.e. ``PULSE_DURATION`` is the 1 sigma of the intensity (see
-    ``BaseParam.def``; ``DispersivePulse.hpp`` documents
-    ``tau_0 = 2 * PULSE_DURATION``). Matching the two envelopes gives
-    ``duration = 2 * PULSE_DURATION``, hence ``PULSE_DURATION = duration / 2``.
-    """
-    return duration_picmi_si / 2.0
-
-
 def scalarProduct(a: list[float], b: list[float]) -> float:
     return np.dot(a, b).tolist()
 

--- a/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
+++ b/lib/python/picongpu/picmi/lasers/dispersive_pulse_laser.py
@@ -12,7 +12,13 @@ from ..copy_attributes import default_converts_to
 from .gaussian_laser import GaussianLaser  # inherit standard Gaussian laser fields
 
 
-@default_converts_to(laser.DispersivePulseLaser)
+@default_converts_to(
+    laser.DispersivePulseLaser,
+    # PICMI's `duration` is the standard 1/e field width (tau), while PIConGPU's
+    # `pulse_duration_si` (aliased as `duration`) is the 1 sigma of the intensity,
+    # i.e. PULSE_DURATION = duration / 2 (#5739)
+    conversions={"duration": lambda self, *args, **kwargs: self._pulse_duration_sigma_si()},
+)
 @typeguard.typechecked
 class DispersivePulseLaser(GaussianLaser):
     """

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -13,7 +13,7 @@ import typeguard
 
 from ...pypicongpu import laser, util
 from ..copy_attributes import default_converts_to
-from .base_laser import BaseLaser, picmi_laser_duration_to_pulse_duration
+from .base_laser import BaseLaser
 from .polarization_type import PolarizationType
 
 
@@ -145,10 +145,20 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
         self.pulse_init = self._compute_pulse_init()
 
     def _pulse_duration_sigma_si(self):
-        # PICMI's `duration` is the standard 1/e field width (tau), while
-        # PIConGPU's laser parameters use PULSE_DURATION = tau / 2 (1 sigma of
-        # the intensity).
-        return picmi_laser_duration_to_pulse_duration(self.duration)
+        """Convert the PICMI-standard laser ``duration`` to the PIConGPU
+        ``PULSE_DURATION`` parameter.
+
+        The PICMI standard defines the Gaussian temporal envelope as
+        ``E ~ exp(-t^2 / duration^2)``, i.e. ``duration`` is the 1/e half width
+        of the electric-field amplitude (see ``PICMI_GaussianLaser``).
+        PIConGPU's Gaussian temporal envelope is
+        ``E ~ exp(-t^2 / (4 * PULSE_DURATION^2))`` (see ``GaussianPulse.hpp``),
+        i.e. ``PULSE_DURATION`` is the 1 sigma of the intensity (see
+        ``BaseParam.def``; ``DispersivePulse.hpp`` documents
+        ``tau_0 = 2 * PULSE_DURATION``). Matching the two envelopes gives
+        ``duration = 2 * PULSE_DURATION``, hence ``PULSE_DURATION = duration / 2``.
+        """
+        return self.duration / 2.0
 
     def check(self):
         util.unsupported("laser name", self.name)

--- a/lib/python/picongpu/picmi/lasers/gaussian_laser.py
+++ b/lib/python/picongpu/picmi/lasers/gaussian_laser.py
@@ -13,11 +13,17 @@ import typeguard
 
 from ...pypicongpu import laser, util
 from ..copy_attributes import default_converts_to
-from .base_laser import BaseLaser
+from .base_laser import BaseLaser, picmi_laser_duration_to_pulse_duration
 from .polarization_type import PolarizationType
 
 
-@default_converts_to(laser.GaussianLaser)
+@default_converts_to(
+    laser.GaussianLaser,
+    # PICMI's `duration` is the standard 1/e field width (tau), while PIConGPU's
+    # `pulse_duration_si` (aliased as `duration`) is the 1 sigma of the intensity,
+    # i.e. PULSE_DURATION = duration / 2 (#5739)
+    conversions={"duration": lambda self, *args, **kwargs: self._pulse_duration_sigma_si()},
+)
 @typeguard.typechecked
 class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
     """
@@ -32,7 +38,9 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
         Spot size (1/e^2 radius) of the laser at focus [m].
 
     - duration : float
-        Full-width-half-maximum (FWHM) duration of the pulse [s].
+        Duration of the Gaussian laser pulse [s], defined as ``tau`` in the
+        electric-field envelope ``E ~ exp(-t^2 / tau^2)`` (i.e. the 1/e half
+        width of the field amplitude), consistent with the PICMI standard.
 
     - propagation_direction : list[float]
         Normalized vector of propagation direction.
@@ -135,6 +143,12 @@ class GaussianLaser(picmistandard.PICMI_GaussianLaser, BaseLaser):
         self.phi0 = self.phi0 or 0.0
         self._validate_common_properties()
         self.pulse_init = self._compute_pulse_init()
+
+    def _pulse_duration_sigma_si(self):
+        # PICMI's `duration` is the standard 1/e field width (tau), while
+        # PIConGPU's laser parameters use PULSE_DURATION = tau / 2 (1 sigma of
+        # the intensity).
+        return picmi_laser_duration_to_pulse_duration(self.duration)
 
     def check(self):
         util.unsupported("laser name", self.name)

--- a/lib/python/picongpu/pypicongpu/laser.py
+++ b/lib/python/picongpu/pypicongpu/laser.py
@@ -77,7 +77,7 @@ class _BaseLaser(BaseModel):
     wave_length_si: float = Field(alias="wavelength", gt=0.0)
     """wave length in m"""
     pulse_duration_si: float = Field(alias="duration", gt=0.0)
-    """duration in s (1 sigma)"""
+    """duration in s (1 sigma of a standard gaussian for the intensity (E^2))"""
     focus_pos_si: Annotated[tuple[_Component, _Component, _Component], BeforeValidator(validate_component_vector)] = (
         Field(alias="focal_position")
     )

--- a/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
+++ b/lib/python/test/picongpu/quick/picmi/test_gaussian_laser.py
@@ -7,11 +7,20 @@ License: GPLv3+
 
 from picongpu import picmi
 
+import os
+import re
+import tempfile
 from unittest import TestCase
 from math import sqrt
 from scipy.constants import c
 
 import pytest
+
+
+def _pulse_duration(duration_picmi_si):
+    """PIConGPU PULSE_DURATION (1 sigma of the intensity) from the PICMI-standard
+    duration (1/e field width), i.e. PULSE_DURATION = duration / 2"""
+    return duration_picmi_si / 2.0
 
 
 class TestPicmiGaussianLaser(TestCase):
@@ -36,7 +45,9 @@ class TestPicmiGaussianLaser(TestCase):
         # translated
         assert pypic_laser.wave_length_si == 1
         assert pypic_laser.waist_si == 2
-        assert pypic_laser.pulse_duration_si == 3
+        # picmi `duration` is the PICMI-standard 1/e field width (tau);
+        # pypicongpu `pulse_duration_si` is PULSE_DURATION = tau / 2 (#5739)
+        assert abs(pypic_laser.pulse_duration_si - _pulse_duration(3)) < 1e-15
         assert pypic_laser.propagation_direction == (0, 1, 0)
         assert pypic_laser.polarization_direction == (0, 0, 1)
         assert pypic_laser.focus_pos_si == (5, 4, 5)
@@ -49,13 +60,46 @@ class TestPicmiGaussianLaser(TestCase):
         assert pypic_laser.huygens_surface_positions == [[1, -1], [1, -1], [1, -1]]
 
         # computed values
+        # pulse_init is counted in units of PULSE_DURATION (1 sigma of the intensity) (#5739)
         assert (
             abs(
                 -2.0
                 * picmi_laser.centroid_position[1]
                 / picmi_laser.propagation_direction[1]
                 / c
-                / picmi_laser.duration
+                / _pulse_duration(picmi_laser.duration)
+                - pypic_laser.pulse_init
+            )
+            < 1e-10
+        )
+
+    def test_duration_converted_to_pulse_duration(self):
+        """picmi `duration` is the PICMI-standard 1/e field width, pypicongpu expects PULSE_DURATION = duration / 2 (#5739)"""
+        duration_picmi_si = 30e-15
+        picmi_laser = picmi.GaussianLaser(
+            wavelength=800e-9,
+            waist=12e-6,
+            duration=duration_picmi_si,
+            focal_position=[0.0, 5e-6, 0.0],
+            centroid_position=[0.0, -5e-6, 0.0],
+            propagation_direction=[0, 1, 0],
+            polarization_direction=[1, 0, 0],
+            a0=1.0,
+        )
+        # the picmi object keeps the duration value as given (PICMI contract)
+        assert picmi_laser.duration == duration_picmi_si
+
+        pypic_laser = picmi_laser.get_as_pypicongpu()
+        # the translated value is PULSE_DURATION = duration / 2 (1 sigma of the intensity)
+        assert abs(pypic_laser.pulse_duration_si - _pulse_duration(duration_picmi_si)) < 1e-24
+        # pulse_init is also counted in units of PULSE_DURATION
+        assert (
+            abs(
+                -2.0
+                * picmi_laser.centroid_position[1]
+                / picmi_laser.propagation_direction[1]
+                / c
+                / _pulse_duration(picmi_laser.duration)
                 - pypic_laser.pulse_init
             )
             < 1e-10
@@ -366,3 +410,59 @@ class TestPicmiGaussianLaser(TestCase):
                 propagation_direction=[0, 1, 0],
                 polarization_direction=[1, 0, 0],
             )
+
+
+def test_duration_rendered_into_incident_field():
+    """the PICMI-standard duration (1/e field width) must be rendered as PULSE_DURATION = duration / 2
+    (1 sigma of the intensity) in incidentField.param (#5739)"""
+    duration_picmi_si = 30e-15
+    laser = picmi.GaussianLaser(
+        wavelength=800e-9,
+        waist=12e-6,
+        duration=duration_picmi_si,
+        focal_position=[8.5, 2, 21],
+        centroid_position=[8.5, -3, 21],
+        propagation_direction=[0, 1, 0],
+        polarization_direction=[1, 0, 0],
+        a0=1.0,
+    )
+    grid = picmi.Cartesian3DGrid(
+        number_of_cells=[128, 512, 256],
+        lower_bound=[0, 0, 0],
+        upper_bound=[17, 192, 42],
+        lower_boundary_conditions=["periodic", "periodic", "open"],
+        upper_boundary_conditions=["periodic", "periodic", "open"],
+    )
+    solver = picmi.ElectromagneticSolver(method="Yee", grid=grid)
+    sim = picmi.Simulation(time_step_size=1, max_steps=2, solver=solver)
+    sim.add_laser(laser, None)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = os.path.join(tmpdir, "input")
+        sim.write_input_file(output_dir)
+        rendered_path = os.path.join(output_dir, "include", "picongpu", "param", "incidentField.param")
+        with open(rendered_path) as rendered_file:
+            rendered = rendered_file.read()
+
+    match = re.search(r"PULSE_DURATION_SI = ([0-9eE.+-]+);", rendered)
+    assert match is not None, "PULSE_DURATION_SI not found in rendered incidentField.param"
+    assert abs(float(match.group(1)) - _pulse_duration(duration_picmi_si)) < 1e-24
+    # the passed duration (tau) itself must not end up in PULSE_DURATION_SI
+    assert abs(float(match.group(1)) - duration_picmi_si) > 1e-14
+
+
+def test_dispersive_pulse_laser_duration_converted_to_pulse_duration():
+    """DispersivePulseLaser inherits the PICMI-standard duration semantics of GaussianLaser (#5739)"""
+    duration_picmi_si = 30e-15
+    picmi_laser = picmi.DispersivePulseLaser(
+        wavelength=800e-9,
+        waist=12e-6,
+        duration=duration_picmi_si,
+        focal_position=[0.0, 5e-6, 0.0],
+        centroid_position=[0.0, -5e-6, 0.0],
+        propagation_direction=[0, 1, 0],
+        polarization_direction=[1, 0, 0],
+        a0=1.0,
+    )
+    pypic_laser = picmi_laser.get_as_pypicongpu()
+    assert abs(pypic_laser.pulse_duration_si - _pulse_duration(duration_picmi_si)) < 1e-24


### PR DESCRIPTION
Internal mirror of upstream PR #5739 (branch `fix/5739`), the bottom layer of the laser stack.

Use the PICMI-standard laser duration (1/e field width) in the (Gaussian/DispersivePulse) lasers:

- PICMI's `duration` is the 1/e amplitude field width `tau` (`E ~ exp(-t^2/tau^2)`), while PIConGPU's `PULSE_DURATION_SI` is the 1 sigma of the intensity, i.e. `PULSE_DURATION = duration / 2`.
- Adds `BaseLaser._pulse_duration_sigma_si()` (default: `duration`), overridden in `GaussianLaser` to return `duration / 2`, and converts `duration -> pulse_duration_si` accordingly on translation; `pulse_init` is counted in units of `PULSE_DURATION`.
- Updates the docstrings and adds quick tests for the conversion.

Stack position (bottom): `dev` <- this PR (`fix/5739`).
